### PR TITLE
test: uni-v2 pair

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,5 +4,5 @@ test-r55 = "test --package r55"
 test-e2e = "test --package r55 --test e2e"
 test-erc20 = "test --package r55 --test erc20"
 test-erc721 = "test --package r55 --test erc721"
-
+test-univ2 = "test --package r55 --test uniswap-v2"
 

--- a/eth-riscv-runtime/src/lib.rs
+++ b/eth-riscv-runtime/src/lib.rs
@@ -102,6 +102,18 @@ pub fn keccak256(offset: u64, size: u64) -> U256 {
     U256::from_limbs([first, second, third, fourth])
 }
 
+pub fn this() -> Address {
+    let (first, second, third): (u64, u64, u64);
+    unsafe {
+        asm!("ecall", lateout("a0") first, lateout("a1") second, lateout("a2") third, in("t0") u8::from(Syscall::Address));
+    }
+    let mut bytes = [0u8; 20];
+    bytes[0..8].copy_from_slice(&first.to_be_bytes());
+    bytes[8..16].copy_from_slice(&second.to_be_bytes());
+    bytes[16..20].copy_from_slice(&third.to_be_bytes()[..4]);
+    Address::from_slice(&bytes)
+}
+
 pub fn msg_sender() -> Address {
     let (first, second, third): (u64, u64, u64);
     unsafe {

--- a/eth-riscv-runtime/src/types/lock.rs
+++ b/eth-riscv-runtime/src/types/lock.rs
@@ -1,0 +1,70 @@
+// TODO: use TLOAD/TSTORE rather than SLOAD/STORE once transient storage is implemented 
+use super::*;
+
+/// A storage primitive that implements a reentrancy guard using the RAII pattern.
+///
+/// `Lock<E>` wraps a `Slot<bool>` to track lock state and uses a generic error type `E` 
+/// to provide type-safe error handling when attempting to acquire an already locked resource.  
+///
+/// The `LockGuard` returned by `fn acquire()` automatically releases the lock when it goes out of scope,
+/// ensuring the lock is dropped even if the code returns early or panics.
+pub struct Lock<E> {
+    unlocked: Slot<bool>,
+    _pd: PhantomData<E>,
+}
+
+impl<E> StorageLayout for Lock<E> {
+    fn allocate(first: u64, second: u64, third: u64, fourth: u64) -> Self {
+        Self {
+            unlocked: Slot::allocate(first, second, third, fourth),
+            _pd: PhantomData,
+        }
+    }
+}
+
+impl<E> Default for Lock<E> {
+    fn default() -> Self {
+        let mut lock = Self {
+            unlocked: Slot::default(),
+            _pd: PhantomData,
+        };
+        lock.unlocked.write(true);
+        lock
+    }
+}
+
+impl<E> Lock<E> {
+    /// Initialize a new lock in the unlocked state
+    pub fn new() -> Self {
+        Self::default()
+    }
+    
+    /// Attempts to acquire the lock, returning a guard that releases the lock when dropped.
+    /// When unable to acquire the lock, returns `locked_err`.
+    pub fn acquire(&mut self, locked_err: E) -> Result<LockGuard<E>, E> {
+        if !self.unlocked.read() {
+            return Err(locked_err);
+        }
+        
+        self.unlocked.write(false);
+        Ok(LockGuard { slot_id: self.unlocked.id(), _pd: PhantomData })
+    }
+    
+    /// Checks if the lock is currently unlocked
+    pub fn is_unlocked(&self) -> bool {
+        self.unlocked.read()
+    }
+}
+
+/// A guard that manages the locking state
+pub struct LockGuard<E> {
+    slot_id: U256, // Store the key directly
+    _pd: PhantomData<E>, 
+}
+
+impl<E> Drop for LockGuard<E> {
+    fn drop(&mut self) {
+        // Write `true` back directly using the stored key and the static __write method
+        <Slot<bool> as StorageStorable>::__write(self.slot_id, true);
+    }
+}

--- a/eth-riscv-runtime/src/types/lock.rs
+++ b/eth-riscv-runtime/src/types/lock.rs
@@ -6,8 +6,11 @@ use super::*;
 /// `Lock<E>` wraps a `Slot<bool>` to track lock state and uses a generic error type `E` 
 /// to provide type-safe error handling when attempting to acquire an already locked resource.  
 ///
+/// The `Lock` should be initialized in the contract constructor, by calling its `fn initialize()`.
+///
 /// The `LockGuard` returned by `fn acquire()` automatically releases the lock when it goes out of scope,
 /// ensuring the lock is dropped even if the code returns early or panics.
+#[derive(Default)]
 pub struct Lock<E> {
     unlocked: Slot<bool>,
     _pd: PhantomData<E>,
@@ -22,21 +25,10 @@ impl<E> StorageLayout for Lock<E> {
     }
 }
 
-impl<E> Default for Lock<E> {
-    fn default() -> Self {
-        let mut lock = Self {
-            unlocked: Slot::default(),
-            _pd: PhantomData,
-        };
-        lock.unlocked.write(true);
-        lock
-    }
-}
-
 impl<E> Lock<E> {
-    /// Initialize a new lock in the unlocked state
-    pub fn new() -> Self {
-        Self::default()
+    /// Initialize a new lock in the unlocked state. Should only be created in the constructor.
+    pub fn initialize(&mut self) {
+        self.unlocked.write(true);
     }
     
     /// Attempts to acquire the lock, returning a guard that releases the lock when dropped.

--- a/eth-riscv-runtime/src/types/mod.rs
+++ b/eth-riscv-runtime/src/types/mod.rs
@@ -14,6 +14,9 @@ pub use mapping::Mapping;
 mod slot;
 pub use slot::Slot;
 
+mod lock;
+pub use lock::Lock;
+
 ///  STORAGE TYPES:
 ///  > Must implement the following traits:
 ///     - `StorageLayout`: Allows the `storage` macro to allocate a storage slot.

--- a/eth-riscv-runtime/src/types/slot.rs
+++ b/eth-riscv-runtime/src/types/slot.rs
@@ -9,6 +9,12 @@ pub struct Slot<V> {
     _pd: PhantomData<V>,
 }
 
+impl<V> Slot<V> {
+    pub(crate) fn id(&self) -> U256 {
+        self.id
+    }
+}
+
 impl<V> StorageLayout for Slot<V> {
     fn allocate(first: u64, second: u64, third: u64, fourth: u64) -> Self {
         Self {
@@ -50,7 +56,7 @@ where
     }
 }
 
-// Implementation of several std traits to improve dev-ex
+// Implementation of several `core::ops` traits to improve dev-ex
 impl<V> Add<V> for Slot<V>
 where
     Self: StorageStorable<Value = V>,

--- a/eth-riscv-syscalls/src/lib.rs
+++ b/eth-riscv-syscalls/src/lib.rs
@@ -55,6 +55,7 @@ macro_rules! syscalls {
 // as described on https://www.evm.codes.
 //
 // t0: 0x20, opcode for keccak256, a0: offset, a1: size, returns keccak256 hash
+// t0: 0x30, opcode for address, returns an address
 // t0: 0x32, opcode for origin, returns an address
 // t0: 0x33, opcode for caller, returns an address
 // t0: 0x34, opcode for callvalue, a0: first limb, a1: second limb, a2: third limb, a3: fourth limb, returns 256-bit value
@@ -77,6 +78,7 @@ macro_rules! syscalls {
 syscalls!(
     // EVM opcodes
     (0x20, Keccak256, "keccak256"),
+    (0x30, Address, "address"),
     (0x32, Origin, "origin"),
     (0x33, Caller, "caller"),
     (0x34, CallValue, "callvalue"),

--- a/examples/erc20/src/lib.rs
+++ b/examples/erc20/src/lib.rs
@@ -85,8 +85,7 @@ impl ERC20 {
         if to == Address::ZERO { return Err(ERC20Error::ZeroAddress) };
 
         // Increase user balance
-        let to_balance = self.balance_of[to].read();
-        self.balance_of[to].write(to_balance + amount);
+        self.balance_of[to] += amount;
 
         // Increase total supply
         self.total_supply += amount;
@@ -121,14 +120,13 @@ impl ERC20 {
 
         // Read user balances
         let from_balance = self.balance_of[from].read();
-        let to_balance = self.balance_of[to].read();
 
         // Ensure enough balance
         if from_balance < amount { return Err(ERC20Error::InsufficientBalance(from_balance)) }
 
         // Update state
         self.balance_of[from].write(from_balance - amount);
-        self.balance_of[to].write(to_balance + amount);
+        self.balance_of[to] += amount;
 
         // Emit event + return 
         log::emit(Transfer::new(from, to, amount));
@@ -155,8 +153,7 @@ impl ERC20 {
         self.allowance_of[from][msg_sender].write(allowance - amount);
         self.balance_of[from].write(from_balance - amount);
         
-        let to_balance = self.balance_of[to].read();
-        self.balance_of[to].write(to_balance + amount);
+        self.balance_of[to] += amount;
 
         // Emit event + return 
         log::emit(Transfer::new(from, to, amount));

--- a/examples/erc721/.cargo/config
+++ b/examples/erc721/.cargo/config
@@ -1,8 +1,0 @@
-[target.riscv64imac-unknown-none-elf]
-rustflags = [
-  "-C", "link-arg=-T../../r5-rust-rt.x",
-  "-C", "llvm-args=--inline-threshold=275"
-]
-
-[build]
-target = "riscv64imac-unknown-none-elf"

--- a/examples/erc721/src/lib.rs
+++ b/examples/erc721/src/lib.rs
@@ -98,12 +98,8 @@ impl ERC721 {
 
         // Update state
         self.owner_of[id].write(to);
-        
-        let balance_to = self.balance_of[to].read();
-        self.balance_of[to].write(balance_to + U256::from(1));
-
-        let total_supply = self.total_supply.read();
-        self.total_supply.write(total_supply + U256::from(1));
+        self.balance_of[to] += U256::from(1);
+        self.total_supply += U256::from(1);
         
         // Emit event + return
         log::emit(Transfer::new(Address::ZERO, to, id));
@@ -154,11 +150,8 @@ impl ERC721 {
         self.owner_of[id].write(to);
         self.approval_of[id].write(Address::ZERO);
 
-        let balance_from = self.balance_of[from].read();
-        self.balance_of[from].write(balance_from - U256::from(1));
-
-        let balance_to = self.balance_of[to].read();
-        self.balance_of[to].write(balance_to + U256::from(1));
+        self.balance_of[from] -= U256::from(1);
+        self.balance_of[to] += U256::from(1);
 
         // Emit event + return
         log::emit(Transfer::new(from, to, id));

--- a/examples/uniswap-v2/Cargo.toml
+++ b/examples/uniswap-v2/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "erc20x"
+name = "uniswap-v2"
 version = "0.1.0"
 edition = "2021"
 
@@ -14,13 +14,13 @@ interface-only = []
 contract-derive = { path = "../../contract-derive" }
 eth-riscv-runtime = { path = "../../eth-riscv-runtime" }
 
-erc20 = { path = "../erc20", features = ["interface-only"] }
-
 alloy-core = { version = "0.8.20", default-features = false }
 alloy-sol-types = { version = "0.8.20", default-features = false }
 
+erc20 = { path = "../erc20", features = ["interface-only"] }
+
 [package.metadata.deployable_deps]
-erc20 = { path = "../erc20" }
+pair = { path = "." }
 
 [[bin]]
 name = "runtime"

--- a/examples/uniswap-v2/src/deployable.rs
+++ b/examples/uniswap-v2/src/deployable.rs
@@ -6,17 +6,17 @@ use alloy_core::primitives::{Address, Bytes};
 use eth_riscv_runtime::{create::Deployable, InitInterface, ReadOnly};
 use core::include_bytes;
 
-use erc20::IERC20;
+use crate::pair::IUniswapV2Pair;
 
-const ERC20_BYTECODE: &'static [u8] = include_bytes!("../../../../r55-output-bytecode/erc20.bin");
+const UNISWAP_V2_PAIR_BYTECODE: &'static [u8] = include_bytes!("../../../../r55-output-bytecode/uniswap-v2-pair.bin");
 
-pub struct ERC20;
+pub struct UniswapV2Pair;
 
-impl Deployable for ERC20 {
-    type Interface = IERC20<ReadOnly>;
+impl Deployable for UniswapV2Pair {
+    type Interface = IUniswapV2Pair<ReadOnly>;
 
     fn __runtime() -> &'static [u8] {
-        ERC20_BYTECODE
+        UNISWAP_V2_PAIR_BYTECODE
     }
 }
 

--- a/examples/uniswap-v2/src/factory.rs
+++ b/examples/uniswap-v2/src/factory.rs
@@ -1,0 +1,127 @@
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+use core::default::Default;
+use core::str::FromStr;
+
+use contract_derive::{contract, interface, payable, storage, Error, Event};
+use eth_riscv_runtime::{types::*, *};
+
+use alloy_core::primitives::{address, keccak256 as alloy_keccak, Address, Bytes, B256, U256, U8};
+use crate::deployable::UniswapV2Pair;
+
+// -- EVENTS -------------------------------------------------------------------
+#[derive(Event)]
+pub struct PairCreated {
+    #[indexed]
+    pub token0: Address,
+    #[indexed]
+    pub token1: Address,
+    pub pair: Address,
+    pub total_pairs: U256,
+}
+
+// -- ERRORS -------------------------------------------------------------------
+#[derive(Error)]
+pub enum UniswapV2FactoryError {
+    SameToken,
+    ZeroAddress,
+    Unauthorized,
+    PairExists,
+    InitializationFailed,
+}
+
+// -- CONTRACT -----------------------------------------------------------------
+#[storage]
+pub struct UniswapV2Factory {
+    // Fee configuration
+    fee_to: Slot<Address>,
+    fee_to_setter: Slot<Address>,
+
+    // Pair storage
+    pairs: Mapping<Address, Mapping<Address, Slot<Address>>>,
+    // TODO: handle Vec storage 
+    // all_pairs: Vec<Address>,
+}
+
+#[contract]
+impl UniswapV2Factory {
+    // -- CONSTRUCTOR ----------------------------------------------------------
+    pub fn new(fee_to_setter: Address) -> Self {
+        let mut factory = UniswapV2Factory::default();
+
+        // Set factory as deployer
+        factory.fee_to_setter.write(fee_to_setter);
+
+        factory
+    }
+
+    // -- STATE MODIFYING FUNCTIONS -------------------------------------------
+    pub fn create_pair(&mut self, token_a: Address, token_b: Address) -> Result<Address, UniswapV2FactoryError> {
+        // Perform token checks
+        if token_a == token_b {
+            return Err(UniswapV2FactoryError::SameToken);
+        }
+
+        let (token0, token1) = if token_a < token_b {
+            (token_a, token_b)
+        } else {
+            (token_b, token_a)
+        };
+
+        if token0 == Address::ZERO {
+            return Err(UniswapV2FactoryError::ZeroAddress);
+        }
+        if self.pairs[token0][token1].read() != Address::ZERO {
+            return Err(UniswapV2FactoryError::PairExists)
+        }
+
+        // Deploy pair contract --> TODO: impl CREATE2
+        let mut pair = UniswapV2Pair::deploy(()).with_ctx(&mut *self);
+        pair.initialize(token0, token1).map_err(|_| UniswapV2FactoryError::InitializationFailed)?;
+
+        // Update storage
+        self.pairs[token0][token1].write(pair.address());
+        self.pairs[token1][token0].write(pair.address());
+
+        // Emit event and return the pair address
+        log::emit(PairCreated::new(token0, token1, pair.address(), U256::ZERO));
+
+        Ok(pair.address())
+    }
+
+    pub fn set_fee_to(&mut self, fee_to: Address) -> Result<(), UniswapV2FactoryError> {
+        if msg_sender() != self.fee_to_setter.read() {
+            return Err(UniswapV2FactoryError::Unauthorized);
+        }
+
+        // Update state
+        self.fee_to.write(fee_to); 
+        Ok(())
+    }
+
+    pub fn set_fee_to_setter(&mut self, fee_to_setter: Address) -> Result<(), UniswapV2FactoryError> {
+        if msg_sender() != self.fee_to_setter.read() {
+            return Err(UniswapV2FactoryError::Unauthorized);
+        }
+
+        // Update state
+        self.fee_to_setter.write(fee_to_setter); 
+        Ok(())
+    }
+
+    // -- READ-ONLY FUNCTIONS -------------------------------------------------
+    pub fn fee_to(&self) -> Address {
+        self.fee_to.read()
+    }
+
+    pub fn fee_to_setter(&self) -> Address {
+        self.fee_to_setter.read()
+    }
+
+    pub fn pair(&self, token0: Address, token1: Address) -> Address {
+        self.pairs[token0][token1].read()
+    }
+}
+

--- a/examples/uniswap-v2/src/lib.rs
+++ b/examples/uniswap-v2/src/lib.rs
@@ -1,0 +1,19 @@
+#![no_std]
+#![no_main]
+
+pub mod math;
+pub mod pair;
+pub mod factory;
+pub mod deployable;
+
+use alloy_core::primitives::{Bytes, Address, U256};
+
+#[interface]
+trait IUniswapV2Factory {
+    fn fee_to(&self) -> Address;
+}
+
+#[interface]
+trait IUniswapV2Callee {
+    fn uniswap_v2_call(&self, sender: Address, amount0: U256, amount1: U256, data: Bytes);
+}

--- a/examples/uniswap-v2/src/math.rs
+++ b/examples/uniswap-v2/src/math.rs
@@ -1,0 +1,170 @@
+use alloy_core::primitives::U256;
+use core::ops::{Add, BitAnd, BitOrAssign, BitXor, Div, Mul, MulAssign, Sub};
+
+#[derive(Debug, PartialEq)]
+pub enum MathError {
+    DenominatorIsZero,
+    DenominatorIsLteProdOne,
+}
+
+const ONE: U256 = U256::from_limbs([1, 0, 0, 0]);
+const TWO: U256 = U256::from_limbs([2, 0, 0, 0]);
+const THREE: U256 = U256::from_limbs([3, 0, 0, 0]);
+
+// Code borrowed from: https://github.com/0xKitsune/uniswap-v3-math/blob/main/src/full_math.rs
+pub fn mul_div(x: U256, y: U256, mut denominator: U256) -> Result<U256, MathError> {
+    // 512-bit multiply [prod1 prod0] = x * y
+    // Compute the product mod 2**256 and mod 2**256 - 1
+    // then use the Chinese Remainder Theorem to reconstruct
+    // the 512 bit result. The result is stored in two 256
+    // variables such that product = prod1 * 2**256 + prod0
+    let mm = x.mul_mod(y, U256::MAX);
+
+    let mut prod_0 = x.overflowing_mul(y).0; // Least significant 256 bits of the product
+    let mut prod_1 = mm
+        .overflowing_sub(prod_0)
+        .0
+        .overflowing_sub(U256::from((mm < prod_0) as u8))
+        .0;
+
+    // Handle non-overflow cases, 256 by 256 division
+    if prod_1 == U256::ZERO {
+        if denominator == U256::ZERO {
+            return Err(MathError::DenominatorIsZero);
+        }
+        return Ok(U256::from_limbs(*prod_0.div(denominator).as_limbs()));
+    }
+
+    // Make sure the result is less than 2**256.
+    // Also prevents denominator == 0
+    if denominator <= prod_1 {
+        return Err(MathError::DenominatorIsLteProdOne);
+    }
+
+    // 512 by 256 division.
+
+    // Make division exact by subtracting the remainder from [prod1 prod0]
+    // Compute remainder using mulmod
+    let remainder = x.mul_mod(y, denominator);
+
+    // Subtract 256 bit number from 512 bit number
+    prod_1 = prod_1
+        .overflowing_sub(U256::from((remainder > prod_0) as u8))
+        .0;
+    prod_0 = prod_0.overflowing_sub(remainder).0;
+
+    // Factor powers of two out of denominator
+    // Compute largest power of two divisor of denominator.
+    // Always >= 1.
+    let mut twos = U256::ZERO
+        .overflowing_sub(denominator)
+        .0
+        .bitand(denominator);
+
+    // Divide denominator by power of two
+
+    denominator = denominator.wrapping_div(twos);
+
+    // Divide [prod1 prod0] by the factors of two
+    prod_0 = prod_0.wrapping_div(twos);
+
+    // Shift in bits from prod1 into prod0. For this we need
+    // to flip `twos` such that it is 2**256 / twos.
+    // If twos is zero, then it becomes one
+
+    twos = (U256::ZERO.overflowing_sub(twos).0.wrapping_div(twos)).add(ONE);
+
+    prod_0.bitor_assign(prod_1 * twos);
+
+    // Invert denominator mod 2**256
+    // Now that denominator is an odd number, it has an inverse
+    // modulo 2**256 such that denominator * inv = 1 mod 2**256.
+    // Compute the inverse by starting with a seed that is correct
+    // for four bits. That is, denominator * inv = 1 mod 2**4
+
+    let mut inv = THREE.mul(denominator).bitxor(TWO);
+
+    // Now use Newton-Raphson iteration to improve the precision.
+    // Thanks to Hensel's lifting lemma, this also works in modular
+    // arithmetic, doubling the correct bits in each step.
+
+    inv.mul_assign(TWO - denominator * inv); // inverse mod 2**8
+    inv.mul_assign(TWO - denominator * inv); // inverse mod 2**16
+    inv.mul_assign(TWO - denominator * inv); // inverse mod 2**32
+    inv.mul_assign(TWO - denominator * inv); // inverse mod 2**64
+    inv.mul_assign(TWO - denominator * inv); // inverse mod 2**128
+    inv.mul_assign(TWO - denominator * inv); // inverse mod 2**256
+
+    // Because the division is now exact we can divide by multiplying
+    // with the modular inverse of denominator. This will give us the
+    // correct result modulo 2**256. Since the preconditions guarantee
+    // that the outcome is less than 2**256, this is the final result.
+    // We don't need to compute the high bits of the result and prod1
+    // is no longer required.
+
+    Ok(U256::from_le_slice((prod_0 * inv).as_le_slice()))
+}
+
+pub fn sqrt(y: U256) -> U256 {
+    if y > THREE {
+        let mut z = y;
+        let mut x = y / TWO + ONE;
+        while x < z {
+            z = x;
+            x = (y / x + x) / TWO;
+        }
+        z
+    } else if y != U256::ZERO {
+        ONE
+    } else {
+        U256::ZERO
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const Q128: U256 = U256::from_limbs([0, 0, 1, 0]);
+
+    #[test]
+    fn test_fails_mul_div() {
+        //Revert if the denominator is zero
+        let result = mul_div(Q128, U256::from(5), U256::ZERO);
+        assert_eq!(result, Err(MathError::DenominatorIsZero));
+
+        // Revert if the denominator is zero and numerator overflows
+        let result = mul_div(Q128, Q128, U256::ZERO);
+        assert_eq!(result, Err(MathError::DenominatorIsLteProdOne));
+
+        // Revert if the output overflows U256
+        let result = mul_div(Q128, Q128, ONE);
+        assert_eq!(result, Err(MathError::DenominatorIsLteProdOne));
+
+        // Reverts on overflow with all max inputs
+        let result = mul_div(U256::MAX, U256::MAX, U256::MAX.sub(ONE));
+        assert_eq!(result.err().unwrap(), MathError::DenominatorIsLteProdOne);
+
+        // All max inputs
+        let result = mul_div(U256::MAX, U256::MAX, U256::MAX);
+        assert_eq!(result, Ok(U256::MAX));
+
+        // Accurate without phantom overflow
+        let result = mul_div(
+            Q128,
+            U256::from(50).mul(Q128).div(U256::from(100)),
+            U256::from(150).mul(Q128).div(U256::from(100)),
+        );
+        assert_eq!(result, Ok(Q128.div(U256::from(3))));
+
+        // Accurate with phantom overflow
+        let result = mul_div(Q128, U256::from(35).mul(Q128), U256::from(8).mul(Q128));
+        assert_eq!(result, Ok(U256::from(4375).mul(Q128).div(U256::from(1000)))
+        );
+
+        // Accurate with phantom overflow and repeating decimal
+        let result = mul_div(Q128, U256::from(1000).mul(Q128), U256::from(3000).mul(Q128));
+        assert_eq!(result, Ok(Q128.div(U256::from(3))));
+    }
+}
+

--- a/examples/uniswap-v2/src/pair.rs
+++ b/examples/uniswap-v2/src/pair.rs
@@ -1,0 +1,542 @@
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+use core::default::Default;
+use core::str::FromStr;
+
+use alloc::vec;
+use contract_derive::{contract, interface, payable, storage, Error, Event};
+use eth_riscv_runtime::{block::{chain_id, timestamp}, types::*, *};
+
+use alloy_core::primitives::{address, keccak256 as alloy_keccak, Address, Bytes, B256, U256, U8};
+use erc20::IERC20;
+
+use crate::{math::{mul_div, sqrt, MathError}, IUniswapV2Callee, IUniswapV2Factory};
+
+// -- EVENTS -------------------------------------------------------------------
+#[derive(Event)]
+pub struct Transfer {
+    #[indexed]
+    pub from: Address,
+    #[indexed]
+    pub to: Address,
+    pub value: U256,
+}
+
+#[derive(Event)]
+pub struct Approval {
+    #[indexed]
+    pub owner: Address,
+    #[indexed]
+    pub spender: Address,
+    pub value: U256,
+}
+
+#[derive(Event)]
+pub struct Mint {
+    #[indexed]
+    pub sender: Address,
+    pub amount0: U256,
+    pub amount1: U256,
+}
+
+#[derive(Event)]
+pub struct Burn {
+    #[indexed]
+    pub sender: Address,
+    pub amount0: U256,
+    pub amount1: U256,
+    #[indexed]
+    pub to: Address,
+}
+
+#[derive(Event)]
+pub struct Swap {
+    #[indexed]
+    pub sender: Address,
+    pub amount0_in: U256,
+    pub amount1_in: U256,
+    pub amount0_out: U256,
+    pub amount1_out: U256,
+    #[indexed]
+    pub to: Address,
+}
+
+#[derive(Event)]
+pub struct Sync {
+    pub reserve0: U256,
+    pub reserve1: U256,
+}
+
+// -- ERRORS -------------------------------------------------------------------
+#[derive(Error)]
+pub enum UniswapV2PairError {
+    Locked,
+    FailedCallback,
+    OnlyFactory,
+    InsufficientOutputAmount,
+    InsufficientLiquidity,
+    InvalidTo,
+    InsufficientInputAmount,
+    MathError,
+    Overflow,
+    InsufficientLiquidityMinted,
+    InsufficientLiquidityBurned,
+    TransferFailed,
+    Expired,
+    InvalidSignature,
+    K,
+}
+
+impl From<MathError> for UniswapV2PairError {
+    fn from(_: MathError) -> Self {
+        Self::MathError
+    }
+}
+
+// -- CONTRACT -----------------------------------------------------------------
+#[storage]
+pub struct UniswapV2Pair {
+    // ERC20 storage
+    total_supply: Slot<U256>,
+    balance_of: Mapping<Address, Slot<U256>>,
+    allowance: Mapping<Address, Mapping<Address, Slot<U256>>>,
+    // TODO: handle string storage to support ERC20 metadata
+    // name: Slot<String>,
+    // symbol: Slot<String>,
+    // decimals: Slot<u8>,
+
+    // Domain separator storage (for EIP-712)
+    domain_separator: Slot<B256>,
+    nonces: Mapping<Address, Slot<U256>>,
+
+    // Pair storage
+    factory: Slot<Address>,
+    token0: Slot<Address>,
+    token1: Slot<Address>,
+
+    reserve0: Slot<U256>,
+    reserve1: Slot<U256>,
+    last_block_at: Slot<U256>,
+
+    price0_cumulative_last: Slot<U256>,
+    price1_cumulative_last: Slot<U256>,
+    k_last: Slot<U256>,
+
+    lock: Lock<UniswapV2PairError>,
+}
+
+pub const MINIMUM_LIQUIDITY: U256 = U256::from_limbs([1000, 0, 0, 0]); // 1_000
+
+// keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+pub const PERMIT_TYPEHASH: [u8; 32] = [
+    0x6e, 0x71, 0xed, 0xae, 0x12, 0xb1, 0xb9, 0x7f, 0x4d, 0x1f, 0x60, 0x37, 0x0f, 0xef, 0x10, 0x10,
+    0x5f, 0xa2, 0xfa, 0xae, 0x01, 0x26, 0x11, 0x4a, 0x16, 0x9c, 0x64, 0x84, 0x5d, 0x61, 0x26, 0xc9,
+];
+
+#[contract]
+impl UniswapV2Pair {
+    // -- CONSTRUCTOR ----------------------------------------------------------
+    pub fn new() -> Self {
+        let mut pair = UniswapV2Pair::default();
+
+        // Set factory as deployer
+        pair.factory.write(msg_sender());
+
+        // // Calculate domain separator for EIP-712
+        // // TODO: implement a user-frendly version of keccack256 -> it should use `Bytes` rather than a raw pointer
+        // let domain_separator = alloy_core::primitives::keccak256(
+        //     (
+        //         alloy_keccak("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+        //         alloy_keccak(Bytes::from_str("Uniswap V2").unwrap()),
+        //         alloy_keccak(Bytes::from_str("1").unwrap()),
+        //         chain_id(),
+        //         pair.address(),
+        //     ).abi_encode()
+        // );
+
+        pair
+    }
+
+    pub fn initialize(
+        &mut self,
+        token0: Address,
+        token1: Address,
+    ) -> Result<(), UniswapV2PairError> {
+        if msg_sender() != self.factory.read() {
+            return Err(UniswapV2PairError::OnlyFactory);
+        }
+
+        self.token0.write(token0);
+        self.token1.write(token1);
+
+        Ok(())
+    }
+
+    // -- ERC20 - STATE MODIFYING FUNCTIONS ---------------------------------------------------
+    fn _mint(&mut self, to: Address, value: U256) {
+        self.total_supply += value;
+        self.balance_of[to] += value;
+
+        log::emit(Transfer::new(Address::ZERO, to, value));
+    }
+
+    fn _burn(&mut self, from: Address, value: U256) {
+        self.balance_of[from] -= value;
+        self.total_supply -= value;
+
+        log::emit(Transfer::new(from, Address::ZERO, value));
+    }
+
+    fn _approve(&mut self, owner: Address, spender: Address, value: U256) {
+        self.allowance[owner][spender].write(value);
+
+        log::emit(Approval::new(owner, spender, value));
+    }
+
+    fn _transfer(&mut self, from: Address, to: Address, value: U256) {
+        self.balance_of[from] -= value;
+        self.balance_of[to] += value;
+
+        log::emit(Transfer::new(from, to, value));
+    }
+
+    pub fn approve(&mut self, spender: Address, value: U256) -> bool {
+        self._approve(msg_sender(), spender, value);
+        true
+    }
+
+    pub fn transfer(&mut self, to: Address, value: U256) -> bool {
+        self._transfer(msg_sender(), to, value);
+        true
+    }
+
+    pub fn transfer_from(&mut self, from: Address, to: Address, value: U256) -> bool {
+        let msg_sender = msg_sender();
+        let allowance = self.allowance[from][msg_sender].read();
+
+        if allowance != U256::MAX {
+            self.allowance[from][msg_sender].write(allowance - value);
+        }
+
+        self._transfer(from, to, value);
+        true
+    }
+
+    // TODO: figure out how to use U8 as apparently it doesn't impl `SolValue`:
+    // https://github.com/alloy-rs/core/blob/cd4b8d5e77e38d71534742fa4fb0505505b2ca2d/crates/sol-types/src/types/value.rs#L221
+    //
+    // pub fn permit(&mut self, owner: Address, spender: Address, value: U256, deadline: U256, _v: U8, _r: B256, _s: B256) -> Result<(), UniswapV2PairError> {
+    //     if deadline < timestamp() {
+    //         return Err(UniswapV2PairError::Expired)
+    //     }
+    //
+    //     let nonce = self.nonces[owner].read() + U256::from(1);
+    //     self.nonces[owner].write(nonce);
+    //
+    //     let _digest = alloy_core::primitives::keccak256((
+    //         vec![0x19, 0x01],
+    //         self.domain_separator.read(),
+    //         alloy_core::primitives::keccak256((PERMIT_TYPEHASH, owner, spender, value, nonce, deadline).abi_encode())
+    //     ).abi_encode_packed());
+    //
+    //     // TODO: Implement ECDSA verification (ecrecover)
+    //     let signer = Address::ZERO;
+    //
+    //     if signer == Address::ZERO || signer != owner {
+    //         return Err(UniswapV2PairError::InvalidSignature)
+    //     }
+    //     self._approve(owner, spender, value);
+    //
+    //     Ok(())
+    // }
+
+    // -- ERC20 - READ-ONLY FUNCTIONS ---------------------------------------------------
+    pub fn total_supply(&self) -> U256 {
+        self.total_supply.read()
+    }
+
+    pub fn balance_of(&self, owner: Address) -> U256 {
+        self.balance_of[owner].read()
+    }
+
+    pub fn allowance(&self, owner: Address, spender: Address) -> U256 {
+        self.allowance[owner][spender].read()
+    }
+
+    // TODO: use Lock in the state modifying pair fns
+
+    // -- AMM PAIR - STATE MODIFYING FUNCTIONS -----------------------------------------------
+    fn _update(&mut self, balance0: U256, balance1: U256, reserve0: U256, reserve1: U256) {
+        let block_timestamp = timestamp();
+        let elapsed = block_timestamp - self.last_block_at.read();
+
+        // Update price accumulators
+        if elapsed != U256::ZERO && reserve0 != U256::ZERO && reserve1 != U256::ZERO {
+            self.price0_cumulative_last +=
+                mul_div(reserve1, U256::from(elapsed), reserve0).unwrap_or(U256::ZERO);
+            self.price1_cumulative_last +=
+                mul_div(reserve0, U256::from(elapsed), reserve1).unwrap_or(U256::ZERO);
+        }
+
+        // Update reserves
+        self.reserve0.write(balance0);
+        self.reserve1.write(balance1);
+        self.last_block_at.write(block_timestamp);
+
+        log::emit(Sync::new(balance0, balance1));
+    }
+
+    fn _mint_fee(&mut self, reserve0: U256, reserve1: U256) -> Result<bool, UniswapV2PairError> {
+        let factory_contract = IUniswapV2Factory::new(self.factory.read()).with_ctx(&mut *self);
+        let fee_to = factory_contract.fee_to().unwrap_or(Address::ZERO);
+
+        let is_fee_active = fee_to != Address::ZERO;
+        let k_last = self.k_last.read();
+
+        // If fee is on, mint liquidity equivalent to 1/6th of the growth in sqrt(k)
+        if is_fee_active {
+            if k_last != U256::ZERO {
+                let root_k = sqrt(reserve0 * reserve1);
+                let root_k_last = sqrt(k_last);
+
+                if root_k > root_k_last {
+                    let liquidity = mul_div(
+                        self.total_supply.read(),
+                        root_k - root_k_last,
+                        root_k * U256::from(5) + root_k_last,
+                    )?;
+
+                    if liquidity != U256::ZERO {
+                        self._mint(fee_to, liquidity);
+                    }
+                }
+            }
+        } else if k_last != U256::ZERO {
+            self.k_last.write(U256::ZERO);
+        }
+
+        Ok(is_fee_active)
+    }
+
+    pub fn mint(&mut self, to: Address) -> Result<U256, UniswapV2PairError> {
+        let _guard = self.lock.acquire(UniswapV2PairError::Locked)?;
+
+        let (reserve0, reserve1, _) = self.get_reserves();
+        let is_fee_active = self._mint_fee(reserve0, reserve1)?;
+
+        let token0 = IERC20::new(self.token0.read()).with_ctx(&mut *self);
+        let token1 = IERC20::new(self.token1.read()).with_ctx(&mut *self);
+
+        // Get total supply, current balances, and compute the amounts
+        let balance0 = token0.balance_of(self.address()).unwrap_or(U256::ZERO);
+        let balance1 = token1.balance_of(self.address()).unwrap_or(U256::ZERO);
+        let amount0 = balance0 - reserve0;
+        let amount1 = balance1 - reserve1;
+
+        let total_supply = self.total_supply.read();
+
+        let liquidity = {
+            if total_supply == U256::ZERO {
+                // Permanently lock the first `MINIMUM_LIQUIDITY` tokens
+                self._mint(Address::ZERO, MINIMUM_LIQUIDITY);
+                sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
+            } else {
+                core::cmp::min(
+                    mul_div(amount0, total_supply, reserve0)?,
+                    mul_div(amount1, total_supply, reserve1)?,
+                )
+            }
+        };
+
+        if liquidity == U256::ZERO {
+            return Err(UniswapV2PairError::InsufficientLiquidityMinted);
+        }
+
+        // Update the AMM reserves
+        self._mint(to, liquidity);
+        self._update(balance0, balance1, reserve0, reserve1);
+        if is_fee_active {
+            self.k_last.write(balance0 * balance1)
+        };
+
+        // Emit the event and return the liquidity
+        log::emit(Mint::new(msg_sender(), amount0, amount1));
+
+        Ok(liquidity)
+    }
+
+    pub fn burn(&mut self, to: Address) -> Result<(U256, U256), UniswapV2PairError> {
+        let _guard = self.lock.acquire(UniswapV2PairError::Locked)?;
+
+        let (reserve0, reserve1, _) = self.get_reserves();
+        let is_fee_active = self._mint_fee(reserve0, reserve1)?;
+
+        let token0 = IERC20::new(self.token0.read()).with_ctx(&mut *self);
+        let token1 = IERC20::new(self.token1.read()).with_ctx(&mut *self);
+
+        // Get total supply, current balances, and compute the amounts
+        let balance0 = token0.balance_of(self.address()).unwrap_or(U256::ZERO);
+        let balance1 = token1.balance_of(self.address()).unwrap_or(U256::ZERO);
+
+        let liquidity = self.balance_of[self.address()].read();
+        let total_supply = self.total_supply.read();
+
+        let amount0 = mul_div(liquidity, balance0, total_supply)?;
+        let amount1 = mul_div(liquidity, balance1, total_supply)?;
+
+        if amount0 <= U256::ZERO || amount1 <= U256::ZERO {
+            return Err(UniswapV2PairError::InsufficientLiquidityBurned);
+        }
+
+        // Burn the LP tokens and transfer the amounts back
+        self._burn(self.address(), liquidity);
+
+        self._transfer(token0.address(), to, amount0);
+        self._transfer(token1.address(), to, amount1);
+
+        // Update the AMM reserves
+        let balance0 = token0.balance_of(self.address()).unwrap_or(U256::ZERO);
+        let balance1 = token1.balance_of(self.address()).unwrap_or(U256::ZERO);
+
+        self._update(balance0, balance1, reserve0, reserve1);
+        if is_fee_active {
+            self.k_last.write(balance0 * balance1)
+        };
+
+        // Emit the event and return the token amounts
+        log::emit(Burn::new(msg_sender(), amount0, amount1, to));
+
+        Ok((amount0, amount1))
+    }
+
+    pub fn swap(
+        &mut self,
+        amount0_out: U256,
+        amount1_out: U256,
+        to: Address,
+        data: Bytes,
+    ) -> Result<(), UniswapV2PairError> {
+        let _guard = self.lock.acquire(UniswapV2PairError::Locked)?;
+
+        if amount0_out == U256::ZERO && amount1_out == U256::ZERO {
+            return Err(UniswapV2PairError::InsufficientOutputAmount);
+        }
+
+        let (reserve0, reserve1, _) = self.get_reserves();
+        if amount0_out >= reserve0 || amount1_out >= reserve1 {
+            return Err(UniswapV2PairError::InsufficientLiquidity);
+        }
+
+        let token0 = IERC20::new(self.token0.read()).with_ctx(&mut *self);
+        let token1 = IERC20::new(self.token1.read()).with_ctx(&mut *self);
+
+        if to == token0.address() || to == token1.address() {
+            return Err(UniswapV2PairError::InvalidTo);
+        }
+
+        // Optimistically transfer tokens
+        if amount0_out > U256::ZERO {
+            self._transfer(token0.address(), to, amount0_out);
+        }
+
+        if amount1_out > U256::ZERO {
+            self._transfer(token1.address(), to, amount1_out);
+        }
+
+        // Swap callback
+        if !data.is_empty() {
+            IUniswapV2Callee::new(to)
+                .with_ctx(&mut *self)
+                .uniswap_v2_call(msg_sender(), amount0_out, amount1_out, data)
+                .ok_or(UniswapV2PairError::FailedCallback)?;
+        }
+
+        // Get balances after transfers and possibly callback
+        let balance0 = token0.balance_of(self.address()).unwrap_or(U256::ZERO);
+        let balance1 = token1.balance_of(self.address()).unwrap_or(U256::ZERO);
+
+        // Calculate amounts in
+        let amount0_in = if balance0 > reserve0 - amount0_out {
+            balance0 - (reserve0 - amount0_out)
+        } else {
+            U256::ZERO
+        };
+
+        let amount1_in = if balance1 > reserve1 - amount1_out {
+            balance1 - (reserve1 - amount1_out)
+        } else {
+            U256::ZERO
+        };
+
+        if amount0_in == U256::ZERO && amount1_in == U256::ZERO {
+            return Err(UniswapV2PairError::InsufficientInputAmount);
+        }
+
+        // Verify `K` constant (with fee)
+        let balance0_adjusted = balance0 * U256::from(1000) - amount0_in * U256::from(3);
+        let balance1_adjusted = balance1 * U256::from(1000) - amount1_in * U256::from(3);
+
+        if balance0_adjusted * balance1_adjusted < reserve0 * reserve1 * U256::from(1_000_000) {
+            return Err(UniswapV2PairError::K);
+        }
+
+        // Update reserves
+        self._update(balance0, balance1, reserve0, reserve1);
+
+        log::emit(Swap::new(msg_sender(), amount0_in, amount1_in, amount0_out, amount1_out, to));
+
+        Ok(())
+    }
+
+    pub fn skim(&mut self, to: Address) -> Result<(), UniswapV2PairError> {
+        let _guard = self.lock.acquire(UniswapV2PairError::Locked)?;
+
+        let token0 = IERC20::new(self.token0.read()).with_ctx(&mut *self);
+        let token1 = IERC20::new(self.token1.read()).with_ctx(&mut *self);
+
+        let balance0 = token0.balance_of(self.address()).unwrap_or(U256::ZERO);
+        let balance1 = token1.balance_of(self.address()).unwrap_or(U256::ZERO);
+
+        self._transfer(token0.address(), to, balance0 - self.reserve0.read());
+        self._transfer(token1.address(), to, balance1 - self.reserve1.read());
+
+        Ok(())
+    }
+
+    pub fn sync(&mut self) -> Result<(), UniswapV2PairError> {
+        let _guard = self.lock.acquire(UniswapV2PairError::Locked)?;
+
+        let token0 = IERC20::new(self.token0.read()).with_ctx(&mut *self);
+        let token1 = IERC20::new(self.token1.read()).with_ctx(&mut *self);
+
+        let balance0 = token0.balance_of(self.address()).unwrap_or(U256::ZERO);
+        let balance1 = token1.balance_of(self.address()).unwrap_or(U256::ZERO);
+
+        self._update(balance0, balance1, self.reserve0.read(), self.reserve1.read());
+
+        Ok(())
+    }
+
+    // -- AMM PAIR - READ-ONLY FUNCTIONS -----------------------------------------------------
+    pub fn factory(&self) -> Address {
+        self.factory.read()
+    }
+
+    pub fn token0(&self) -> Address {
+        self.token0.read()
+    }
+
+    pub fn token1(&self) -> Address {
+        self.token1.read()
+    }
+
+    pub fn get_reserves(&self) -> (U256, U256, U256) {
+        (
+            self.reserve0.read(),
+            self.reserve1.read(),
+            self.last_block_at.read(),
+        )
+    }
+}

--- a/r55-compile/Cargo.toml
+++ b/r55-compile/Cargo.toml
@@ -14,3 +14,5 @@ tracing-subscriber.workspace = true
 
 toml = "0.8"
 syn = { version = "1.0", features = ["full"] }
+pathdiff = "0.2.1"
+prettyplease = "0.1"

--- a/r55-compile/src/ast.rs
+++ b/r55-compile/src/ast.rs
@@ -1,0 +1,194 @@
+use std::{collections::HashSet, fmt::Write};
+use syn::{parse_file, File, Item, UseGroup, UseName, UsePath, UseTree};
+
+use crate::types::CompileError;
+
+pub fn process_lib(
+    content: &str,
+    contract_mods: &[&String],
+) -> Result<(Vec<Item>, HashSet<String>), CompileError> {
+    let file = parse_file(content)?;
+
+    // Extract normalized imports
+    let raw_imports = get_imports(&file)?;
+
+    let mut lib_imports = HashSet::new();
+    for import in raw_imports.into_iter() {
+        _ = import.strip_prefix("crate::");
+        if !contract_mods.iter().any(|m| import.starts_with(*m)) {
+            lib_imports.insert(import);
+        };
+    }
+
+    // Create a filtered version of the file
+    let mut filtered_items = Vec::new();
+
+    // Filter out contract module declarations and process other items
+    for item in file.items.iter() {
+        match item {
+            // Check for module declarations
+            Item::Mod(item_mod) => {
+                let mod_name = item_mod.ident.to_string();
+
+                // Skip module declarations for contract modules
+                if contract_mods.iter().any(|m| **m == mod_name) {
+                    continue;
+                }
+
+                // Skip generated deployable module (manually added when needed by the contract)
+                if mod_name == "deployable" {
+                    continue;
+                }
+
+                // Keep other module declarations
+                filtered_items.push(item.clone());
+            }
+
+            // Skip all use statements as they are proccessed independently
+            Item::Use(_) => continue,
+
+            // Keep all other items
+            _ => filtered_items.push(item.clone()),
+        }
+    }
+
+    Ok((filtered_items, lib_imports))
+}
+
+pub fn process_contract_module(
+    content: &str,
+    lib_imports: &mut HashSet<String>,
+) -> Result<Vec<Item>, CompileError> {
+    let file = parse_file(content)?;
+
+    // Create a filtered version of the file
+    let mut filtered_items = Vec::new();
+
+    // Extract normalized imports, and flatten them
+    for import in get_imports(&file)?.into_iter() {
+        let adj_import = match import.split_once("crate::") {
+            Some((_, i)) => {
+                if i == "*" || !i.contains("::") {
+                    continue;
+                } else {
+                    i.into()
+                }
+            }
+            None => match import.split_once("super::") {
+                Some((_, i)) => {
+                    if i == "*" || !i.contains("::") {
+                        continue;
+                    } else {
+                        i.into()
+                    }
+                }
+                None => import,
+            },
+        };
+
+        lib_imports.insert(adj_import);
+    }
+
+    // Process each item
+    for item in file.items.iter() {
+        // Skip all use statements as they are proccessed independently
+        if let Item::Use(_) = item {
+            continue;
+        }
+
+        filtered_items.push(item.clone());
+    }
+
+    Ok(filtered_items)
+}
+
+pub fn flatten_lib(
+    mut lib_ast: Vec<Item>,
+    contract_mod_ast: Vec<Item>,
+    imports: HashSet<String>,
+) -> String {
+    lib_ast.extend(contract_mod_ast);
+
+    // Create the new file AST with the flattened items
+    let file = File {
+        shebang: None,
+        items: lib_ast,
+        attrs: Vec::new(),
+    };
+
+    // Craft the new file by defining the attributes, joining all imports, and the unparsed items
+    let mut flattened = "#![no_std]\n#![no_main]\n\n".to_string();
+    if imports.iter().any(|i| i.starts_with("deployable")) {
+        flattened.push_str("mod deployable;\n");
+    }
+    for import in imports {
+        _ = writeln!(flattened, "use {};", import);
+    }
+
+    format!("{}\n{}", flattened, prettyplease::unparse(&file))
+}
+
+fn get_imports(file: &File) -> Result<HashSet<String>, CompileError> {
+    let mut imports = HashSet::new();
+
+    // Iterate through all items in the file
+    for item in file.items.iter() {
+        if let Item::Use(use_item) = item {
+            // Process each use statement
+            process_use_tree(&mut imports, "", 0, &use_item.tree)?;
+        }
+    }
+
+    Ok(imports)
+}
+
+fn process_use_tree(
+    result: &mut HashSet<String>,
+    prefix: &str,
+    depth: usize,
+    tree: &UseTree,
+) -> Result<(), CompileError> {
+    match tree {
+        UseTree::Path(UsePath { ident, tree, .. }) => {
+            let new_prefix = if depth == 0 {
+                ident.to_string()
+            } else {
+                format!("{}::{}", prefix, ident)
+            };
+            process_use_tree(result, &new_prefix, depth + 1, tree)?;
+        }
+        UseTree::Group(UseGroup { items, .. }) => {
+            for item in items.iter() {
+                process_use_tree(result, prefix, depth + 1, item)?;
+            }
+        }
+        UseTree::Name(UseName { ident, .. }) => {
+            let path = if depth == 0 {
+                ident.to_string()
+            } else {
+                format!("{}::{}", prefix, ident)
+            };
+            result.insert(path);
+        }
+        UseTree::Rename(rename) => {
+            let path = if depth == 0 {
+                format!("{} as {}", rename.ident, rename.rename)
+            } else {
+                format!("{}::{} as {}", prefix, rename.ident, rename.rename)
+            };
+            result.insert(path);
+        }
+        UseTree::Glob(_) => {
+            let path = if depth == 0 {
+                return Err(CompileError::InvalidImport(
+                    "Global imports are not allowed",
+                ));
+            } else {
+                format!("{}::*", prefix)
+            };
+            result.insert(path);
+        }
+    }
+
+    Ok(())
+}

--- a/r55-compile/src/generate.rs
+++ b/r55-compile/src/generate.rs
@@ -1,0 +1,396 @@
+use std::{fmt::Write, fs, path::Path};
+use toml::Value;
+use tracing::{debug, info};
+
+use crate::{
+    ast,
+    helpers::{format_toml_table, get_contract_name, get_deployable_deps},
+    types::{CompileError, ContractProject, ContractTarget, GeneratedContract},
+};
+
+/// Generate deployable implementation for the contract dependencies of an R55 contract.
+/// Can generate the files in both, the source (working dir), or the temp one (generated inside `target/`).
+pub fn generate_deployable(
+    contract: &GeneratedContract,
+    target_source: bool,
+) -> Result<(), CompileError> {
+    if contract.deps.is_empty() {
+        return Ok(());
+    }
+
+    debug!(
+        "GENERATING DEPLOYABLE FOR {} (target_source: {})",
+        contract.name, target_source
+    );
+
+    let mut content = String::new();
+
+    // Add header comments + common imports
+    content.push_str("//! Auto-generated based on Cargo.toml dependencies\n");
+    content.push_str(
+        "//! This file provides `Deployable` implementations for contract dependencies\n",
+    );
+    content.push_str("//! TODO (phase-2): rather than using `fn deploy(args: Args)`, figure out the constructor selector from the contract dependency\n\n");
+    content.push_str("use alloy_core::primitives::{Address, Bytes};\n");
+    content.push_str("use eth_riscv_runtime::{create::Deployable, InitInterface, ReadOnly};\n");
+    content.push_str("use core::include_bytes;\n\n");
+
+    // Add imports for each dependency
+    for (dep_name, same_project) in &contract.deps {
+        debug!(" > {} (same project: {})", dep_name, same_project);
+        // Keep original module name (lowercase package name)
+        let module_name = dep_name.to_lowercase().replace("-", "_");
+
+        // For interface name, use uppercase I + camel case name (IERC20)
+        let interface_name = format!("I{}", get_contract_name(dep_name));
+
+        content.push_str(
+            if target_source && *same_project {
+                let original_name = contract.get_original_name(&module_name);
+                format!("use crate::{}::{};\n", original_name, interface_name)
+            } else {
+                format!("use {}::{};\n", module_name, interface_name)
+            }
+            .as_str(),
+        );
+    }
+    content.push('\n');
+
+    // Add bytecode constants for each dependency
+    for (dep_name, same_project) in &contract.deps {
+        // Use uppercase for constant name
+        let const_name = dep_name.to_uppercase().replace('-', "_");
+
+        // Calculate the output bytecode path relative to the contract's directory
+        let bytecode_path = if !target_source && *same_project {
+            Path::new("../../../../../r55-output-bytecode").join(format!("{}.bin", dep_name))
+        } else {
+            Path::new("../../../../r55-output-bytecode").join(format!("{}.bin", dep_name))
+        };
+
+        content.push_str(&format!(
+            "const {}_BYTECODE: &'static [u8] = include_bytes!(\"{}\");\n",
+            const_name,
+            bytecode_path.display()
+        ));
+    }
+    content.push('\n');
+
+    // Add `Deployable` implementation for each dependency
+    for (dep_name, _same_project) in &contract.deps {
+        let struct_name = get_contract_name(dep_name);
+        let interface_name = format!("I{}", struct_name);
+
+        content.push_str(&format!("pub struct {};\n\n", struct_name));
+        content.push_str(&format!("impl Deployable for {} {{\n", struct_name));
+        content.push_str(&format!(
+            "    type Interface = {}<ReadOnly>;\n\n",
+            interface_name
+        ));
+        content.push_str("    fn __runtime() -> &'static [u8] {\n");
+        content.push_str(&format!(
+            "        {}_BYTECODE\n",
+            dep_name.to_uppercase().replace('-', "_")
+        ));
+        content.push_str("    }\n");
+        content.push_str("}\n\n");
+    }
+
+    // Write to file
+    let output_path = if !target_source {
+        debug!("TEMP DIR: {:?}", contract.path);
+        contract.path.join("src").join("deployable.rs")
+    } else {
+        debug!("WORKING DIR: {:?}", contract.original_source_path);
+        contract
+            .original_source_path
+            .join("src")
+            .join("deployable.rs")
+    };
+    fs::write(&output_path, content)?;
+
+    info!(
+        "Generated {:?} for contract: {}",
+        output_path, contract.name
+    );
+
+    Ok(())
+}
+
+/// Generate temporary crates for all input R55 contract targets
+pub fn generate_temp_crates(
+    projects: &[ContractProject],
+    temp_dir: &Path,
+    project_root: &Path,
+) -> Result<Vec<GeneratedContract>, CompileError> {
+    let mut generated_contracts = Vec::new();
+
+    for project in projects {
+        debug!("Generating temporary crates for project: {}", project.name);
+
+        for target in &project.targets {
+            let target_temp_dir = temp_dir.join(&project.name).join(&target.module);
+
+            fs::create_dir_all(&target_temp_dir)?;
+            fs::create_dir_all(target_temp_dir.join("src"))?;
+
+            // Create the `GeneratedContract` instance
+            let deployable_deps = get_deployable_deps(project, target);
+            let contract = GeneratedContract {
+                path: target_temp_dir,
+                name: target.generated_package.clone(),
+                deps: deployable_deps,
+                original_source_path: target
+                    .source_file
+                    .parent()
+                    .unwrap()
+                    .parent()
+                    .unwrap()
+                    .to_path_buf(),
+            };
+
+            // Populate the temp dir with the modified files from the working dir
+            generate_cargo_toml(project, target, &contract)?;
+            decouple_contract_module(project, target, &contract.path)?;
+            generate_cargo_config(&contract.path, project_root)?;
+
+            generated_contracts.push(contract);
+        }
+    }
+
+    Ok(generated_contracts)
+}
+
+/// Generate a modified `Cargo.toml` for a R55 temporary crate
+fn generate_cargo_toml(
+    project: &ContractProject,
+    target: &ContractTarget,
+    contract: &GeneratedContract,
+) -> Result<(), CompileError> {
+    let mut cargo_toml = String::new();
+
+    // Basic R55 template
+    writeln!(
+        cargo_toml,
+        r#"[package]
+name = "{}"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+
+[features]
+default = []
+deploy = []
+interface-only = []
+
+[dependencies]
+"#,
+        contract.name
+    )?;
+
+    // Process base dependencies
+    for (dep_name, dep_info) in &project.deps {
+        match dep_info {
+            Value::Table(dep_table) => {
+                let mut dep_table_adj = dep_table.clone();
+                let mut is_generated = false;
+
+                // Adjust path dependencies
+                if let Some(Value::String(rel_path)) = dep_table.get("path") {
+                    if rel_path == "." {
+                        if target.is_self_reference(dep_name) {
+                            continue;
+                        }
+
+                        if contract.name != project.name {
+                            is_generated = true;
+                        }
+                    }
+
+                    dep_table_adj.insert(
+                        "path".into(),
+                        // For contract deps from the same project, use relative path to the generated dir
+                        if is_generated {
+                            Value::String(format!("../{}", dep_name))
+                        }
+                        // Otherwise, calculate relative path to the dependency location
+                        else {
+                            let source_rel_path = Path::new(rel_path);
+                            let source_abs_path =
+                                project.path.join(source_rel_path).canonicalize()?;
+                            let rel_path_from_target =
+                                pathdiff::diff_paths(&source_abs_path, &contract.path).ok_or_else(
+                                    || {
+                                        CompileError::PathError(format!(
+                                            "Failed to calculate relative path from {:?} to {:?}",
+                                            &contract.path, source_abs_path
+                                        ))
+                                    },
+                                )?;
+                            Value::String(rel_path_from_target.display().to_string())
+                        },
+                    );
+                }
+
+                writeln!(
+                    cargo_toml,
+                    "{} = {}",
+                    if is_generated {
+                        format!("{}-{}", &project.name, dep_name)
+                    } else {
+                        dep_name.into()
+                    },
+                    format_toml_table(&dep_table_adj)?
+                )?;
+            }
+            _ => writeln!(cargo_toml, "{} = {}", dep_name, dep_info)?,
+        }
+    }
+
+    // Process deployable dependencies
+    for (dep_name, same_project) in &project.deployable_deps {
+        if *same_project && dep_name != &contract.name {
+            if let Some((_, original_mod_name)) =
+                dep_name.split_once(&format!("{}-", &project.name))
+            {
+                _ = writeln!(
+                    cargo_toml,
+                    r#"{} = {{ path = "../{}", features = ["interface-only"] }}"#,
+                    dep_name, original_mod_name
+                );
+            }
+        }
+    }
+
+    // Add bin targets
+    cargo_toml.push_str(
+        r#"
+[[bin]]
+name = "runtime"
+path = "src/lib.rs"
+
+[[bin]]
+name = "deploy"
+path = "src/lib.rs"
+required-features = ["deploy"]
+
+[profile.release]
+lto = true
+opt-level = "z"
+"#,
+    );
+
+    // Write to file
+    fs::write(contract.path.join("Cargo.toml"), cargo_toml)?;
+
+    Ok(())
+}
+
+/// Create `.cargo/config.toml` in the temporary crate
+fn generate_cargo_config(target_dir: &Path, project_root: &Path) -> Result<(), CompileError> {
+    let cargo_dir = target_dir.join(".cargo");
+    fs::create_dir_all(&cargo_dir)?;
+
+    // Calculate relative path from target directory to project root's r5-rust-rt.x
+    let rust_rt_path = project_root.join("r5-rust-rt.x");
+    let rel_rust_rt_path = pathdiff::diff_paths(&rust_rt_path, target_dir).ok_or_else(|| {
+        CompileError::PathError(format!(
+            "Failed to calculate relative path from {:?} to {:?}",
+            target_dir, rust_rt_path
+        ))
+    })?;
+
+    let config_content = format!(
+        r#"[target.riscv64imac-unknown-none-elf]
+rustflags = [
+  "-C", "link-arg=-T{}",
+  "-C", "llvm-args=--inline-threshold=275"
+]
+
+[build]
+target = "riscv64imac-unknown-none-elf"
+"#,
+        rel_rust_rt_path.display()
+    );
+
+    fs::write(cargo_dir.join("config.toml"), config_content)?;
+
+    Ok(())
+}
+
+/// Decouple a contract module from a project, by merging and flattening the project lib, the common modules, and the contract module itself.
+///
+/// If the contract is directly defined on `lib.rs`, the generated crate matches the working dir
+fn decouple_contract_module(
+    project: &ContractProject,
+    target: &ContractTarget,
+    target_dir: &Path,
+) -> Result<(), CompileError> {
+    let src_dir = target_dir.join("src");
+    let contract_modules: Vec<_> = project.targets.iter().map(|t| &t.module).collect();
+
+    // If a contract is defined in `lib.rs` directly, keep as it is, as it must be a single-contract project
+    if target.source_file.file_name().unwrap().to_str().unwrap() == "lib.rs" {
+        let lib_content = fs::read_to_string(&target.source_file)?;
+        fs::write(src_dir.join("lib.rs"), lib_content)?;
+    }
+    // Otherwise, merge and flatten both `lib.rs` and the contract module
+    else {
+        // Filter `lib.rs` to remove imports, attributes, and contract module declarations
+        let lib_rs_path = project.path.join("src").join("lib.rs");
+        let lib_content = fs::read_to_string(&lib_rs_path)?;
+
+        let (lib_ast, mut lib_imports) = ast::process_lib(&lib_content, &contract_modules)?;
+
+        // Filter contract module content to remove imports and attributes
+        let contract_module_path = target.source_file.clone();
+        let contract_content = fs::read_to_string(&contract_module_path)?;
+
+        let contract_ast = ast::process_contract_module(&contract_content, &mut lib_imports)?;
+
+        // Combine the filtered content and imports. Then write it into the generated `lib.rs`
+        let flattened_content = ast::flatten_lib(lib_ast, contract_ast, lib_imports);
+        fs::write(src_dir.join("lib.rs"), flattened_content)?;
+
+        debug!(
+            "Generated flattened `lib.rs` for contract: {}",
+            target.ident
+        );
+    }
+
+    // Always copy shared modules (without contracts)
+    for module_name in &project.shared_modules {
+        let module_path = project.path.join("src").join(format!("{}.rs", module_name));
+
+        if module_path.exists() {
+            let module_content = fs::read_to_string(&module_path)?;
+            fs::write(src_dir.join(format!("{}.rs", module_name)), module_content)?;
+        } else {
+            // Try `module/mod.rs` structure
+            let mod_dir_path = project.path.join("src").join(module_name);
+            let mod_file_path = mod_dir_path.join("mod.rs");
+
+            if mod_file_path.exists() {
+                // Create the module directory and copy its content
+                let target_mod_dir = src_dir.join(module_name);
+                fs::create_dir_all(&target_mod_dir)?;
+
+                let mod_content = fs::read_to_string(&mod_file_path)?;
+                fs::write(target_mod_dir.join("mod.rs"), mod_content)?;
+
+                if let Ok(entries) = fs::read_dir(mod_dir_path) {
+                    for entry in entries.filter_map(|e| e.ok()) {
+                        let path = entry.path();
+                        if path.is_file() && path.file_name().unwrap() != "mod.rs" {
+                            let file_name = path.file_name().unwrap();
+                            fs::copy(&path, target_mod_dir.join(file_name))?;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/r55-compile/src/helpers.rs
+++ b/r55-compile/src/helpers.rs
@@ -1,0 +1,181 @@
+use std::{collections::HashMap, fmt::Write, fs, path::Path};
+use syn::{Attribute, ItemImpl};
+use toml::{map::Map, Value};
+use tracing::debug;
+
+use crate::types::{CompileError, ContractProject, ContractTarget, GeneratedContract};
+
+/// Finds all R55 smart-contract projects in a directory
+pub fn find_r55_projects(dir: &Path) -> Result<Vec<ContractProject>, CompileError> {
+    let mut examples = Vec::new();
+
+    // Scan subdirectories for potential examples
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.filter_map(|e| e.ok()) {
+            let path = entry.path();
+
+            // Skip if not a directory
+            if !path.is_dir() {
+                continue;
+            }
+
+            // Check for `Cargo.toml`
+            let cargo_path = path.join("Cargo.toml");
+            if !cargo_path.exists() {
+                continue;
+            }
+
+            // Try to parse as R55 contract project
+            match ContractProject::try_from_path(&cargo_path) {
+                Ok(project) => {
+                    examples.push(project);
+                }
+                Err(e) => {
+                    debug!("Skipping directory {:?}: {}", path, e);
+                }
+            }
+        }
+    }
+
+    Ok(examples)
+}
+
+/// Sort generated contracts based on their dependencies
+pub fn sort_generated_contracts(
+    contracts: Vec<GeneratedContract>,
+) -> Result<Vec<GeneratedContract>, CompileError> {
+    // Create dependency mapping
+    let mut dependency_map: HashMap<String, Vec<String>> = HashMap::new();
+    for contract in &contracts {
+        dependency_map.insert(
+            contract.name.clone(),
+            contract.deps.iter().map(|(d, _)| d.into()).collect(),
+        );
+    }
+
+    // Keep track of sorted and remaining contracts
+    let mut sorted = Vec::new();
+    let mut remaining = contracts;
+
+    // Continue until all contracts are sorted
+    while !remaining.is_empty() {
+        let initial_len = remaining.len();
+        let mut next_remaining = Vec::new();
+
+        for contract in remaining {
+            let deps = dependency_map.get(&contract.name).unwrap();
+
+            // Check if all dependencies are already in sorted list
+            let all_deps_sorted = deps
+                .iter()
+                .all(|dep| sorted.iter().any(|c: &GeneratedContract| &c.name == dep));
+
+            if all_deps_sorted {
+                sorted.push(contract);
+            } else {
+                next_remaining.push(contract);
+            }
+        }
+
+        remaining = next_remaining;
+
+        // If no progress was made, we have a cycle
+        if remaining.len() == initial_len && !remaining.is_empty() {
+            return Err(CompileError::CyclicDependency);
+        }
+    }
+
+    Ok(sorted)
+}
+
+/// Whether a an array of attributes contains `contract`
+pub fn has_contract_attribute(attrs: &[Attribute]) -> bool {
+    attrs
+        .iter()
+        .any(|attr| attr.path.segments.len() == 1 && attr.path.segments[0].ident == "contract")
+}
+
+/// Extract the struct name from an item implementation
+pub fn get_struct_name(item_impl: &ItemImpl) -> Option<String> {
+    match &*item_impl.self_ty {
+        syn::Type::Path(type_path) if !type_path.path.segments.is_empty() => {
+            // Get the last segment of the path (the type name)
+            let segment = type_path.path.segments.last().unwrap();
+            Some(segment.ident.to_string())
+        }
+        _ => None,
+    }
+}
+
+/// Extract a camel-cased contract identifier from a package name
+pub fn get_contract_name(package_name: &str) -> String {
+    let package_name = package_name.replace('_', "-");
+    package_name
+        .split('-')
+        .map(|part| {
+            if part.to_lowercase().starts_with("erc") {
+                part.to_uppercase()
+            } else {
+                part.chars()
+                    .enumerate()
+                    .map(|(i, c)| {
+                        if i == 0 {
+                            c.to_uppercase().to_string()
+                        } else {
+                            c.to_string()
+                        }
+                    })
+                    .collect::<String>()
+            }
+        })
+        .collect::<String>()
+}
+
+/// Filter out the contract from the list of deplyable dependencies in the project
+pub fn get_deployable_deps(
+    project: &ContractProject,
+    target: &ContractTarget,
+) -> Vec<(String, bool)> {
+    let mut dependencies = Vec::new();
+
+    for (dep_name, same_project) in project.deployable_deps.iter() {
+        // Skip self-reference
+        if dep_name == &target.generated_package || dep_name == &target.module {
+            continue;
+        }
+
+        dependencies.push((dep_name.clone(), *same_project));
+    }
+
+    dependencies
+}
+
+/// Format a TOML table as a string
+pub fn format_toml_table(table: &Map<String, Value>) -> Result<String, CompileError> {
+    if table.is_empty() {
+        return Ok("{}".into());
+    }
+
+    let mut result = String::from("{ ");
+    let mut first = true;
+
+    for (k, v) in table {
+        if !first {
+            result.push_str(", ");
+        }
+        first = false;
+        write!(
+            result,
+            "{} = {}",
+            k,
+            if let Value::Table(table) = v {
+                format_toml_table(table)?
+            } else {
+                v.to_string()
+            }
+        )?;
+    }
+
+    result.push_str(" }");
+    Ok(result)
+}

--- a/r55-compile/src/main.rs
+++ b/r55-compile/src/main.rs
@@ -26,7 +26,8 @@ fn main() -> eyre::Result<()> {
     let temp_dir = project_root.join("target").join("r55-generated");
     fs::create_dir_all(&temp_dir)?;
 
-    // Find all R55 projects under the examples directory
+    // TODO: discuss with Leo and Georgios how would importing r55 as a dependency for SC development should look like
+    // Find all R55 projects under the `examples` directory
     let target_dir = project_root.join("examples");
     let projects = find_r55_projects(&target_dir)?;
 

--- a/r55-compile/src/types.rs
+++ b/r55-compile/src/types.rs
@@ -1,0 +1,412 @@
+use std::{
+    collections::{HashMap, HashSet},
+    fmt, fs,
+    io::Read,
+    path::{Path, PathBuf},
+    process::Command,
+};
+use syn::Item;
+use thiserror::Error;
+use toml::Value;
+use tracing::{debug, error, info};
+
+use crate::helpers::{get_struct_name, has_contract_attribute};
+
+#[derive(Debug, Error)]
+pub enum CompileError {
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+    #[error("Parsing error: {0}")]
+    SynError(#[from] syn::Error),
+    #[error("Invalid TOML format: {0}")]
+    TomlError(#[from] toml::de::Error),
+    #[error("Formatting error: {0}")]
+    FormattingError(#[from] std::fmt::Error),
+    #[error("Invalid path: {0}")]
+    PathError(String),
+    #[error("No contract found in file: {0}")]
+    NoContractFound(String),
+    #[error("Cyclic dependency")]
+    CyclicDependency,
+    #[error("Invalid import: {0}")]
+    InvalidImport(&'static str),
+}
+
+/// Represents a contract target within a project
+#[derive(Debug, Clone)]
+pub struct ContractTarget {
+    /// The contract struct name
+    pub ident: String,
+    /// The module name where the contract is defined
+    pub module: String,
+    /// Path to the source file
+    pub source_file: PathBuf,
+    /// Generated package name
+    pub generated_package: String,
+}
+
+/// Represents a source project that may contain multiple smart-contracts
+#[derive(Debug, Clone)]
+pub struct ContractProject {
+    /// Directory path of the example
+    pub path: PathBuf,
+    /// Name of the project directory
+    pub name: String,
+    /// Contract targets within this project
+    pub targets: Vec<ContractTarget>,
+    /// Shared modules used by contracts
+    pub shared_modules: HashSet<String>,
+    /// Dependencies from `Cargo.toml`
+    pub deps: HashMap<String, Value>,
+    /// Deployable contract dependencies
+    pub deployable_deps: HashMap<String, bool>,
+}
+
+/// Represents a generated (temporary) crate under `target/`
+#[derive(Debug, Clone)]
+pub struct GeneratedContract {
+    /// Path to the generated crate
+    pub path: PathBuf,
+    /// Package name of the generated crate
+    pub name: String,
+    /// Deployable dependencies contracts
+    pub deps: Vec<(String, bool)>,
+    /// Original source file path
+    pub original_source_path: PathBuf,
+}
+
+impl ContractTarget {
+    pub fn is_self_reference(&self, dep_name: &String) -> bool {
+        dep_name == &self.module || dep_name == &self.generated_package
+    }
+}
+
+impl fmt::Display for GeneratedContract {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.deps.is_empty() {
+            write!(f, "{}", self.name)
+        } else {
+            write!(f, "{} with deps: [", self.name)?;
+            for (i, dep) in self.deps.iter().enumerate() {
+                if i > 0 {
+                    write!(f, ", ")?;
+                }
+                write!(f, "{}", dep.0)?;
+            }
+            write!(f, "]")
+        }
+    }
+}
+
+impl GeneratedContract {
+    pub fn get_original_name(&self, gen_mod_name: &String) -> String {
+        let mut project_name = self
+            .original_source_path
+            .file_stem()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default()
+            .replace("-", "_");
+        project_name.push('_');
+
+        match gen_mod_name.split_once(&project_name) {
+            Some((_, name)) => name.into(),
+            None => gen_mod_name.into(),
+        }
+    }
+
+    pub fn compile(&self) -> eyre::Result<Vec<u8>> {
+        // First compile runtime
+        self.compile_runtime()?;
+
+        // Then compile deployment code
+        let bytecode = self.compile_deploy()?;
+        let mut prefixed_bytecode = vec![0xff]; // Add the 0xff prefix
+        prefixed_bytecode.extend_from_slice(&bytecode);
+
+        Ok(prefixed_bytecode)
+    }
+
+    fn compile_runtime(&self) -> eyre::Result<Vec<u8>> {
+        debug!("Compiling runtime: {}", self.name);
+
+        let path = self
+            .path
+            .to_str()
+            .ok_or_else(|| eyre::eyre!("Failed to convert path to string: {:?}", self.path))?;
+
+        let status = Command::new("cargo")
+            .arg("+nightly-2025-01-07")
+            .arg("build")
+            .arg("-r")
+            .arg("--lib")
+            .arg("-Z")
+            .arg("build-std=core,alloc")
+            .arg("--target")
+            .arg("riscv64imac-unknown-none-elf")
+            .arg("--bin")
+            .arg("runtime")
+            .current_dir(path)
+            .status()
+            .expect("Failed to execute cargo command");
+
+        if !status.success() {
+            error!("Cargo command failed with status: {}", status);
+            std::process::exit(1);
+        } else {
+            info!("Cargo command completed successfully");
+        }
+
+        let bin_path = PathBuf::from(path)
+            .join("target")
+            .join("riscv64imac-unknown-none-elf")
+            .join("release")
+            .join("runtime");
+
+        let mut file = fs::File::open(&bin_path).map_err(|e| {
+            eyre::eyre!(
+                "Failed to open runtime binary {}: {}",
+                bin_path.display(),
+                e
+            )
+        })?;
+
+        // Read the file contents into a vector
+        let mut bytecode = Vec::new();
+        file.read_to_end(&mut bytecode)
+            .map_err(|e| eyre::eyre!("Failed to read runtime binary: {}", e))?;
+
+        Ok(bytecode)
+    }
+
+    // Requires previous runtime compilation
+    fn compile_deploy(&self) -> eyre::Result<Vec<u8>> {
+        debug!("Compiling deploy: {}", self.name);
+
+        let path = self
+            .path
+            .to_str()
+            .ok_or_else(|| eyre::eyre!("Failed to convert path to string: {:?}", self.path))?;
+
+        let status = Command::new("cargo")
+            .arg("+nightly-2025-01-07")
+            .arg("build")
+            .arg("-r")
+            .arg("--lib")
+            .arg("-Z")
+            .arg("build-std=core,alloc")
+            .arg("--target")
+            .arg("riscv64imac-unknown-none-elf")
+            .arg("--bin")
+            .arg("deploy")
+            .arg("--features")
+            .arg("deploy")
+            .current_dir(path)
+            .status()
+            .expect("Failed to execute cargo command");
+
+        if !status.success() {
+            error!("Cargo command failed with status: {}", status);
+            std::process::exit(1);
+        } else {
+            info!("Cargo command completed successfully");
+        }
+
+        let bin_path = PathBuf::from(path)
+            .join("target")
+            .join("riscv64imac-unknown-none-elf")
+            .join("release")
+            .join("deploy");
+
+        let mut file = fs::File::open(&bin_path).map_err(|e| {
+            eyre::eyre!("Failed to open deploy binary {}: {}", bin_path.display(), e)
+        })?;
+
+        // Read the file contents into a vector
+        let mut bytecode = Vec::new();
+        file.read_to_end(&mut bytecode)
+            .map_err(|e| eyre::eyre!("Failed to read deploy binary: {}", e))?;
+
+        Ok(bytecode)
+    }
+}
+
+impl ContractProject {
+    pub fn try_from_path(cargo_toml_path: &Path) -> Result<ContractProject, CompileError> {
+        let project_dir = cargo_toml_path.parent().ok_or_else(|| {
+            CompileError::PathError(format!(
+                "Failed to get parent directory of {:?}",
+                cargo_toml_path
+            ))
+        })?;
+
+        let project_name = project_dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .ok_or_else(|| {
+                CompileError::PathError(format!(
+                    "Failed to get directory name from {:?}",
+                    project_dir
+                ))
+            })?
+            .to_string();
+
+        // Parse Cargo.toml
+        let cargo_content = fs::read_to_string(cargo_toml_path)?;
+        let cargo_toml: Value = toml::from_str(&cargo_content)?;
+
+        // Extract base package name
+        let base_package_name = cargo_toml
+            .get("package")
+            .and_then(|p| p.get("name"))
+            .and_then(|n| n.as_str())
+            .ok_or_else(|| {
+                CompileError::PathError("Missing package.name in Cargo.toml".to_string())
+            })?
+            .to_string();
+
+        // Extract dependencies
+        let mut deps = HashMap::new();
+        let mut deployable_deps = HashMap::new();
+
+        if let Some(Value::Table(table_deps)) = cargo_toml.get("dependencies") {
+            for (name, details) in table_deps {
+                deps.insert(name.to_owned(), details.to_owned());
+            }
+        }
+
+        if let Some(package_table) = cargo_toml.get("package").and_then(Value::as_table) {
+            if let Some(metadata_table) = package_table.get("metadata").and_then(Value::as_table) {
+                if let Some(deployable_deps_table) = metadata_table
+                    .get("deployable_deps")
+                    .and_then(Value::as_table)
+                {
+                    for (name, details) in deployable_deps_table {
+                        if let Some(dep_table) = details.as_table() {
+                            let same_project = match dep_table.get("path") {
+                                Some(Value::String(rel_path)) => rel_path == ".",
+                                _ => false,
+                            };
+
+                            if same_project {
+                                deployable_deps.insert(format!("{}-{}", project_name, name), true)
+                            } else {
+                                deployable_deps.insert(name.clone(), false)
+                            };
+                        }
+                    }
+                }
+            }
+        }
+
+        // Scan src directory for contract targets and shared modules
+        let src_dir = project_dir.join("src");
+        let lib_rs_path = src_dir.join("lib.rs");
+
+        if !lib_rs_path.exists() {
+            return Err(CompileError::PathError(format!(
+                "Missing src/lib.rs in {:?}",
+                project_dir
+            )));
+        }
+
+        // Parse lib.rs to find module declarations
+        let lib_content = fs::read_to_string(&lib_rs_path)?;
+        let lib_ast = syn::parse_file(&lib_content)?;
+
+        let mut module_names = HashSet::new();
+        for item in &lib_ast.items {
+            if let Item::Mod(item_mod) = item {
+                if item_mod.content.is_none() {
+                    // External module
+                    module_names.insert(item_mod.ident.to_string());
+                }
+            }
+        }
+
+        // Find contract targets in each module
+        let mut targets = Vec::new();
+        let mut shared_modules = HashSet::new();
+
+        for module_name in &module_names {
+            let module_path = src_dir.join(format!("{}.rs", module_name));
+
+            if !module_path.exists() {
+                // Try module/mod.rs structure
+                let alt_module_path = src_dir.join(module_name).join("mod.rs");
+                if !alt_module_path.exists() {
+                    debug!(
+                        "Could not find module file for {} at {:?} or {:?}",
+                        module_name, module_path, alt_module_path
+                    );
+                    continue;
+                }
+            }
+
+            // Parse the module file
+            let module_content = fs::read_to_string(&module_path)?;
+            let module_ast = syn::parse_file(&module_content)?;
+
+            // Look for `#[contract]` annotation on impl blocks
+            let mut has_contract = false;
+            for item in &module_ast.items {
+                if let Item::Impl(item_impl) = item {
+                    if has_contract_attribute(&item_impl.attrs) {
+                        // Found a contract
+                        if let Some(struct_name) = get_struct_name(item_impl) {
+                            has_contract = true;
+
+                            // Generate package name based on project name and module name
+                            let generated_pkg_name = format!("{}-{}", project_name, module_name);
+
+                            targets.push(ContractTarget {
+                                ident: struct_name,
+                                module: module_name.clone(),
+                                source_file: module_path.clone(),
+                                generated_package: generated_pkg_name,
+                            });
+                        }
+                    }
+                }
+            }
+
+            if !has_contract {
+                // If no contract was found, this is a shared module
+                shared_modules.insert(module_name.clone());
+            }
+        }
+
+        if targets.is_empty() {
+            // No contracts found - try to find a contract in `lib.rs`
+            for item in &lib_ast.items {
+                if let Item::Impl(item_impl) = item {
+                    if has_contract_attribute(&item_impl.attrs) {
+                        if let Some(struct_name) = get_struct_name(item_impl) {
+                            // When contract is in lib.rs, use the project name as the generated name
+                            targets.push(ContractTarget {
+                                ident: struct_name,
+                                module: String::new(),
+                                source_file: lib_rs_path.clone(),
+                                generated_package: base_package_name.clone(),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        if targets.is_empty() {
+            return Err(CompileError::NoContractFound(
+                project_dir.to_string_lossy().into(),
+            ));
+        }
+
+        Ok(ContractProject {
+            path: project_dir.to_path_buf(),
+            name: project_name,
+            targets,
+            shared_modules,
+            deps,
+            deployable_deps,
+        })
+    }
+}

--- a/r55/src/exec.rs
+++ b/r55/src/exec.rs
@@ -419,8 +419,25 @@ fn execute_riscv(
                             },
                         });
                     }
+                    Syscall::Address => {
+                        let this_address = interpreter.contract.target_address;
+                        debug!("ADDRESS (THIS): {:?}", this_address);
+
+                        // Break address into 3 u64s and write to registers
+                        let caller_bytes = this_address.as_slice();
+                        let first_u64 = u64::from_be_bytes(caller_bytes[0..8].try_into()?);
+                        emu.cpu.xregs.write(10, first_u64);
+                        let second_u64 = u64::from_be_bytes(caller_bytes[8..16].try_into()?);
+                        emu.cpu.xregs.write(11, second_u64);
+                        let mut padded_bytes = [0u8; 8];
+                        padded_bytes[..4].copy_from_slice(&caller_bytes[16..20]);
+                        let third_u64 = u64::from_be_bytes(padded_bytes);
+                        emu.cpu.xregs.write(12, third_u64);
+                    }
                     Syscall::Caller => {
                         let caller = interpreter.contract.caller;
+                        debug!("CALLER: {:?}", caller);
+
                         // Break address into 3 u64s and write to registers
                         let caller_bytes = caller.as_slice();
                         let first_u64 = u64::from_be_bytes(caller_bytes[0..8].try_into()?);

--- a/r55/src/generated/mod.rs
+++ b/r55/src/generated/mod.rs
@@ -5,11 +5,14 @@ use alloy_core::primitives::Bytes;
 use core::include_bytes;
 
 pub const ERC721_BYTECODE: &[u8] = include_bytes!("../../../r55-output-bytecode/erc721.bin");
-pub const EVM_CALLER_BYTECODE: &[u8] = include_bytes!("../../../r55-output-bytecode/evm-caller.bin");
+pub const EVM_CALLER_BYTECODE: &[u8] =
+    include_bytes!("../../../r55-output-bytecode/evm-caller.bin");
 pub const ERC20_BYTECODE: &[u8] = include_bytes!("../../../r55-output-bytecode/erc20.bin");
 pub const ERC20X_BYTECODE: &[u8] = include_bytes!("../../../r55-output-bytecode/erc20x.bin");
-pub const UNISWAP_V2_PAIR_BYTECODE: &[u8] = include_bytes!("../../../r55-output-bytecode/uniswap-v2-pair.bin");
-pub const UNISWAP_V2_FACTORY_BYTECODE: &[u8] = include_bytes!("../../../r55-output-bytecode/uniswap-v2-factory.bin");
+pub const UNISWAP_V2_PAIR_BYTECODE: &[u8] =
+    include_bytes!("../../../r55-output-bytecode/uniswap-v2-pair.bin");
+pub const UNISWAP_V2_FACTORY_BYTECODE: &[u8] =
+    include_bytes!("../../../r55-output-bytecode/uniswap-v2-factory.bin");
 
 pub fn get_bytecode(contract_name: &str) -> Bytes {
     let initcode = match contract_name {

--- a/r55/src/generated/mod.rs
+++ b/r55/src/generated/mod.rs
@@ -5,14 +5,11 @@ use alloy_core::primitives::Bytes;
 use core::include_bytes;
 
 pub const ERC721_BYTECODE: &[u8] = include_bytes!("../../../r55-output-bytecode/erc721.bin");
-pub const EVM_CALLER_BYTECODE: &[u8] =
-    include_bytes!("../../../r55-output-bytecode/evm-caller.bin");
+pub const EVM_CALLER_BYTECODE: &[u8] = include_bytes!("../../../r55-output-bytecode/evm-caller.bin");
 pub const ERC20_BYTECODE: &[u8] = include_bytes!("../../../r55-output-bytecode/erc20.bin");
 pub const ERC20X_BYTECODE: &[u8] = include_bytes!("../../../r55-output-bytecode/erc20x.bin");
-pub const UNISWAP_V2_PAIR_BYTECODE: &[u8] =
-    include_bytes!("../../../r55-output-bytecode/uniswap-v2-pair.bin");
-pub const UNISWAP_V2_FACTORY_BYTECODE: &[u8] =
-    include_bytes!("../../../r55-output-bytecode/uniswap-v2-factory.bin");
+pub const UNISWAP_V2_PAIR_BYTECODE: &[u8] = include_bytes!("../../../r55-output-bytecode/uniswap-v2-pair.bin");
+pub const UNISWAP_V2_FACTORY_BYTECODE: &[u8] = include_bytes!("../../../r55-output-bytecode/uniswap-v2-factory.bin");
 
 pub fn get_bytecode(contract_name: &str) -> Bytes {
     let initcode = match contract_name {

--- a/r55/src/generated/mod.rs
+++ b/r55/src/generated/mod.rs
@@ -9,6 +9,10 @@ pub const EVM_CALLER_BYTECODE: &[u8] =
     include_bytes!("../../../r55-output-bytecode/evm-caller.bin");
 pub const ERC20_BYTECODE: &[u8] = include_bytes!("../../../r55-output-bytecode/erc20.bin");
 pub const ERC20X_BYTECODE: &[u8] = include_bytes!("../../../r55-output-bytecode/erc20x.bin");
+pub const UNISWAP_V2_PAIR_BYTECODE: &[u8] =
+    include_bytes!("../../../r55-output-bytecode/uniswap-v2-pair.bin");
+pub const UNISWAP_V2_FACTORY_BYTECODE: &[u8] =
+    include_bytes!("../../../r55-output-bytecode/uniswap-v2-factory.bin");
 
 pub fn get_bytecode(contract_name: &str) -> Bytes {
     let initcode = match contract_name {
@@ -16,6 +20,8 @@ pub fn get_bytecode(contract_name: &str) -> Bytes {
         "evm_caller" => EVM_CALLER_BYTECODE,
         "erc20" => ERC20_BYTECODE,
         "erc20x" => ERC20X_BYTECODE,
+        "uniswap_v2_pair" => UNISWAP_V2_PAIR_BYTECODE,
+        "uniswap_v2_factory" => UNISWAP_V2_FACTORY_BYTECODE,
         _ => return Bytes::new(),
     };
 

--- a/r55/tests/uniswap-v2.rs
+++ b/r55/tests/uniswap-v2.rs
@@ -1,0 +1,396 @@
+use alloy_primitives::{address, Address, B256};
+use alloy_sol_types::SolValue;
+use r55::{
+    exec::{deploy_contract, run_tx},
+    get_bytecode,
+    test_utils::{
+        add_balance_to_db, get_calldata, get_selector_from_sig, initialize_logger, ALICE, BOB,
+        CAROL,
+    },
+};
+use revm::InMemoryDB;
+
+const WETH: Address = address!("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+const USDC: Address = address!("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+
+#[cfg(test)]
+mod uniswap_v2_factory_tests {
+    use super::*;
+
+    struct UniswapV2FactorySetup {
+        db: InMemoryDB,
+        factory: Address,
+        fee_to_setter: Address,
+    }
+
+    fn factory_setup(fee_to_setter: Address) -> UniswapV2FactorySetup {
+        initialize_logger();
+        let mut db = InMemoryDB::default();
+
+        // Fund user accounts with some ETH
+        for user in [ALICE, BOB, CAROL] {
+            add_balance_to_db(&mut db, user, 1e18 as u64);
+        }
+
+        // Deploy factory contract
+        let constructor = fee_to_setter.abi_encode();
+        let bytecode = get_bytecode("uniswap_v2_factory");
+        let factory = deploy_contract(&mut db, bytecode, Some(constructor)).unwrap();
+
+        UniswapV2FactorySetup {
+            db,
+            factory,
+            fee_to_setter,
+        }
+    }
+
+    #[test]
+    fn test_factory_initialization() {
+        let UniswapV2FactorySetup {
+            mut db,
+            factory,
+            fee_to_setter,
+        } = factory_setup(ALICE);
+
+        // Check `fee_to`
+        let selector_fee_to_setter = get_selector_from_sig("fee_to_setter()");
+        let fee_to_result = run_tx(&mut db, &factory, selector_fee_to_setter.to_vec(), &ALICE)
+            .expect("Error executing tx")
+            .output;
+
+        assert_eq!(
+            Address::from_word(B256::from_slice(fee_to_result.as_slice())),
+            fee_to_setter,
+            "Initial `fee_to_setter` should be ALICE"
+        );
+
+        // Check `fee_to_setter`
+        let selector_fee_to_setter = get_selector_from_sig("fee_to_setter()");
+        let fee_to_setter_result =
+            run_tx(&mut db, &factory, selector_fee_to_setter.to_vec(), &ALICE)
+                .expect("Error executing tx")
+                .output;
+
+        assert_eq!(
+            Address::from_word(B256::from_slice(fee_to_setter_result.as_slice())),
+            fee_to_setter,
+            "Initial `fee_to_setter` should be ALICE"
+        );
+    }
+
+    fn create_pair_and_validate(token0: Address, token1: Address, pass_flipped: bool) {
+        let UniswapV2FactorySetup {
+            mut db,
+            factory,
+            fee_to_setter: _,
+        } = factory_setup(ALICE);
+
+        // Call `create_pair`
+        let selector_create_pair = get_selector_from_sig("create_pair(address,address)");
+        let calldata_create_pair = get_calldata(
+            selector_create_pair,
+            if pass_flipped {
+                (token1, token0).abi_encode()
+            } else {
+                (token0, token1).abi_encode()
+            },
+        );
+
+        run_tx(&mut db, &factory, calldata_create_pair, &ALICE)
+            .expect("Create pair transaction failed");
+
+        // Verify pair was created by checking getPair
+        let selector_get_pair = get_selector_from_sig("pair(address,address)");
+
+        let calldata_get_pair = get_calldata(selector_get_pair, (token0, token1).abi_encode());
+        let pair_result = run_tx(&mut db, &factory, calldata_get_pair, &ALICE)
+            .expect("Error executing tx")
+            .output;
+
+        // The pair address should not be zero
+        let pair = Address::from_word(B256::from_slice(pair_result.as_slice()));
+        assert_ne!(pair, Address::ZERO, "Pair address should not be zero");
+
+        // Call `token0` and `token1` on the pair contract
+        let selector_token0 = get_selector_from_sig("token0()");
+        let selector_token1 = get_selector_from_sig("token1()");
+        let token0_result = run_tx(&mut db, &pair, selector_token0.to_vec(), &ALICE)
+            .expect("Error executing tx")
+            .output;
+        let token1_result = run_tx(&mut db, &pair, selector_token1.to_vec(), &ALICE)
+            .expect("Error executing tx")
+            .output;
+
+        // Validate tokens
+        assert_eq!(
+            Address::from_word(B256::from_slice(token0_result.as_slice())),
+            token0,
+            "Unexpected token0 address"
+        );
+        assert_eq!(
+            Address::from_word(B256::from_slice(token1_result.as_slice())),
+            token1,
+            "Unexpected token1 address"
+        );
+    }
+
+    #[test]
+    fn test_create_pair_works() {
+        let token0 = USDC;
+        let token1 = WETH;
+
+        // test in correct order (token0 < token1)
+        create_pair_and_validate(token0, token1, false);
+
+        // test in wrong order
+        create_pair_and_validate(token0, token1, true);
+    }
+
+    #[test]
+    fn test_create_pair_identical_addresses() {
+        let UniswapV2FactorySetup {
+            mut db,
+            factory,
+            fee_to_setter: _,
+        } = factory_setup(ALICE);
+
+        let token = WETH;
+
+        // Try to create pair with identical addresses
+        let selector_create_pair = get_selector_from_sig("create_pair(address,address)");
+        let calldata_create_pair = get_calldata(selector_create_pair, (token, token).abi_encode());
+
+        let result = run_tx(&mut db, &factory, calldata_create_pair, &ALICE)
+            .expect_err("Create pair with identical addresses should fail");
+
+        assert!(
+            result.matches_custom_error("UniswapV2FactoryError::SameToken"),
+            "Incorrect error signature for identical addresses"
+        );
+    }
+
+    #[test]
+    fn test_create_pair_zero_address() {
+        let UniswapV2FactorySetup {
+            mut db,
+            factory,
+            fee_to_setter: _,
+        } = factory_setup(ALICE);
+
+        let token = WETH;
+
+        // Try to create pair with zero address
+        let selector_create_pair = get_selector_from_sig("create_pair(address,address)");
+        let calldata_create_pair =
+            get_calldata(selector_create_pair, (token, Address::ZERO).abi_encode());
+
+        let result = run_tx(&mut db, &factory, calldata_create_pair, &ALICE)
+            .expect_err("Create pair with zero address should fail");
+
+        assert!(
+            result.matches_custom_error("UniswapV2FactoryError::ZeroAddress"),
+            "Incorrect error signature for zero address"
+        );
+    }
+
+    #[test]
+    fn test_create_pair_pair_exists() {
+        let UniswapV2FactorySetup {
+            mut db,
+            factory,
+            fee_to_setter: _,
+        } = factory_setup(ALICE);
+
+        let token0 = USDC;
+        let token1 = WETH;
+
+        // Create pair first time
+        let selector_create_pair = get_selector_from_sig("create_pair(address,address)");
+        let calldata_create_pair =
+            get_calldata(selector_create_pair, (token0, token1).abi_encode());
+
+        run_tx(&mut db, &factory, calldata_create_pair.clone(), &ALICE)
+            .expect("Error executing first create_pair tx");
+
+        // Try to create the same pair again
+        let result = run_tx(&mut db, &factory, calldata_create_pair, &ALICE)
+            .expect_err("Create pair should fail when pair already exists");
+
+        assert!(
+            result.matches_custom_error("UniswapV2FactoryError::PairExists"),
+            "Incorrect error signature for pair exists"
+        );
+    }
+
+    #[test]
+    fn test_set_fee_to() {
+        let UniswapV2FactorySetup {
+            mut db,
+            factory,
+            fee_to_setter,
+        } = factory_setup(ALICE);
+
+        let new_fee_to = BOB;
+
+        // Set feeTo
+        let selector_set_fee_to = get_selector_from_sig("set_fee_to(address)");
+        let calldata_set_fee_to = get_calldata(selector_set_fee_to, new_fee_to.abi_encode());
+
+        let set_fee_to_result = run_tx(&mut db, &factory, calldata_set_fee_to, &fee_to_setter)
+            .expect("Error executing set_fee_to tx");
+
+        assert!(set_fee_to_result.status, "Set `fee_to` transaction failed");
+
+        // Verify feeTo was updated
+        let selector_fee_to = get_selector_from_sig("fee_to()");
+        let fee_to_result = run_tx(&mut db, &factory, selector_fee_to.to_vec(), &fee_to_setter)
+            .expect("Error executing tx")
+            .output;
+
+        assert_eq!(
+            Address::from_word(B256::from_slice(fee_to_result.as_slice())),
+            new_fee_to,
+            "feeTo was not updated correctly"
+        );
+    }
+
+    #[test]
+    fn test_set_fee_to_unauthorized() {
+        let UniswapV2FactorySetup {
+            mut db,
+            factory,
+            fee_to_setter: _,
+        } = factory_setup(ALICE);
+
+        let unauthorized = BOB;
+        let new_fee_to = CAROL;
+
+        // Try to set feeTo with unauthorized account
+        let selector_set_fee_to = get_selector_from_sig("set_fee_to(address)");
+        let calldata_set_fee_to = get_calldata(selector_set_fee_to, new_fee_to.abi_encode());
+
+        let result = run_tx(&mut db, &factory, calldata_set_fee_to, &unauthorized)
+            .expect_err("Unauthorized set_fee_to should fail");
+
+        assert!(
+            result.matches_custom_error("UniswapV2FactoryError::Unauthorized"),
+            "Incorrect error signature for unauthorized set_fee_to"
+        );
+    }
+
+    #[test]
+    fn test_set_fee_to_setter() {
+        let UniswapV2FactorySetup {
+            mut db,
+            factory,
+            fee_to_setter,
+        } = factory_setup(ALICE);
+
+        let new_fee_to_setter = BOB;
+
+        // Set feeToSetter
+        let selector_set_fee_to_setter = get_selector_from_sig("set_fee_to_setter(address)");
+        let calldata_set_fee_to_setter =
+            get_calldata(selector_set_fee_to_setter, new_fee_to_setter.abi_encode());
+
+        let set_fee_to_setter_result = run_tx(
+            &mut db,
+            &factory,
+            calldata_set_fee_to_setter,
+            &fee_to_setter,
+        )
+        .expect("Error executing set_fee_to_setter tx");
+
+        assert!(
+            set_fee_to_setter_result.status,
+            "Set feeToSetter transaction failed"
+        );
+
+        // Verify feeToSetter was updated
+        let selector_fee_to_setter = get_selector_from_sig("fee_to_setter()");
+        let fee_to_setter_result =
+            run_tx(&mut db, &factory, selector_fee_to_setter.to_vec(), &ALICE)
+                .expect("Error executing tx")
+                .output;
+
+        assert_eq!(
+            Address::from_slice(&fee_to_setter_result[12..32]),
+            new_fee_to_setter,
+            "feeToSetter was not updated correctly"
+        );
+    }
+
+    #[test]
+    fn test_set_fee_to_setter_unauthorized() {
+        let UniswapV2FactorySetup {
+            mut db,
+            factory,
+            fee_to_setter: _,
+        } = factory_setup(ALICE);
+
+        let unauthorized = BOB;
+        let new_fee_to_setter = CAROL;
+
+        // Try to set feeToSetter with unauthorized account
+        let selector_set_fee_to_setter = get_selector_from_sig("set_fee_to_setter(address)");
+        let calldata_set_fee_to_setter =
+            get_calldata(selector_set_fee_to_setter, new_fee_to_setter.abi_encode());
+
+        let result = run_tx(&mut db, &factory, calldata_set_fee_to_setter, &unauthorized)
+            .expect_err("Unauthorized set_fee_to_setter should fail");
+
+        assert!(
+            result.matches_custom_error("UniswapV2FactoryError::Unauthorized"),
+            "Incorrect error signature for unauthorized set_fee_to_setter"
+        );
+    }
+
+    #[test]
+    fn test_set_fee_to_setter_to_other_then_try_again() {
+        let UniswapV2FactorySetup {
+            mut db,
+            factory,
+            fee_to_setter,
+        } = factory_setup(ALICE);
+
+        let new_fee_to = BOB;
+        let new_fee_to_setter = CAROL;
+
+        // First set feeTo to a new address
+        let selector_set_fee_to = get_selector_from_sig("set_fee_to(address)");
+        let calldata_set_fee_to = get_calldata(selector_set_fee_to, new_fee_to.abi_encode());
+
+        run_tx(&mut db, &factory, calldata_set_fee_to, &fee_to_setter)
+            .expect("Error executing set_fee_to tx");
+
+        // Then set feeToSetter to a new address
+        let selector_set_fee_to_setter = get_selector_from_sig("set_fee_to_setter(address)");
+        let calldata_set_fee_to_setter =
+            get_calldata(selector_set_fee_to_setter, new_fee_to_setter.abi_encode());
+
+        run_tx(
+            &mut db,
+            &factory,
+            calldata_set_fee_to_setter,
+            &fee_to_setter,
+        )
+        .expect("Error executing set_fee_to_setter tx");
+
+        // Try to set feeToSetter again with the original feeToSetter (should fail)
+        let calldata_set_fee_to_setter_again =
+            get_calldata(selector_set_fee_to_setter, BOB.abi_encode());
+
+        let result = run_tx(
+            &mut db,
+            &factory,
+            calldata_set_fee_to_setter_again,
+            &fee_to_setter,
+        )
+        .expect_err("set_fee_to_setter from original account should fail after transfer");
+
+        assert!(
+            result.matches_custom_error("UniswapV2FactoryError::Unauthorized"),
+            "Incorrect error signature for unauthorized set_fee_to_setter after transfer"
+        );
+    }
+}

--- a/r55/tests/uniswap-v2.rs
+++ b/r55/tests/uniswap-v2.rs
@@ -9,7 +9,6 @@ use r55::{
     },
 };
 use revm::InMemoryDB;
-use tracing::{error, warn};
 
 const WETH: Address = address!("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
 const USDC: Address = address!("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
@@ -541,7 +540,6 @@ mod uniswap_v2_pair_tests {
         erc20_mint(&mut db, token1, ALICE, token1_amount);
 
         // Transfer tokens to pair
-        warn!("TRANSFER");
         erc20_transfer(&mut db, token0, pair, token0_amount);
         erc20_transfer(&mut db, token1, pair, token1_amount);
 

--- a/r55/tests/uniswap-v2.rs
+++ b/r55/tests/uniswap-v2.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{address, Address, B256};
+use alloy_primitives::{address, Address, Bytes, B256, U256};
 use alloy_sol_types::SolValue;
 use r55::{
     exec::{deploy_contract, run_tx},
@@ -9,6 +9,7 @@ use r55::{
     },
 };
 use revm::InMemoryDB;
+use tracing::{error, warn};
 
 const WETH: Address = address!("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
 const USDC: Address = address!("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
@@ -391,6 +392,758 @@ mod uniswap_v2_factory_tests {
         assert!(
             result.matches_custom_error("UniswapV2FactoryError::Unauthorized"),
             "Incorrect error signature for unauthorized set_fee_to_setter after transfer"
+        );
+    }
+}
+
+#[cfg(test)]
+mod uniswap_v2_pair_tests {
+    use super::*;
+
+    struct UniswapV2PairSetup {
+        db: InMemoryDB,
+        factory: Address,
+        token0: Address,
+        token1: Address,
+        pair: Address,
+        fee_to_setter: Address,
+    }
+
+    const MINIMUM_LIQUIDITY: U256 = U256::from_limbs([1000, 0, 0, 0]);
+
+    fn pair_setup() -> UniswapV2PairSetup {
+        initialize_logger();
+        let mut db = InMemoryDB::default();
+
+        // Fund user accounts with some ETH
+        for user in [ALICE, BOB, CAROL] {
+            add_balance_to_db(&mut db, user, 1e18 as u64);
+        }
+
+        // Deploy ERC20 test tokens
+        let token_a =
+            deploy_contract(&mut db, get_bytecode("erc20"), Some(ALICE.abi_encode())).unwrap();
+        let token_b =
+            deploy_contract(&mut db, get_bytecode("erc20"), Some(ALICE.abi_encode())).unwrap();
+
+        // Sort tokens by address like uniswap-v2
+        let (token0, token1) = if token_a < token_b {
+            (token_a, token_b)
+        } else {
+            (token_b, token_a)
+        };
+
+        // Deploy factory
+        let factory_bytecode = get_bytecode("uniswap_v2_factory");
+        let factory = deploy_contract(&mut db, factory_bytecode, Some(ALICE.abi_encode())).unwrap();
+
+        // Create pair via factory
+        let selector_create_pair = get_selector_from_sig("create_pair(address,address)");
+        let calldata_create_pair =
+            get_calldata(selector_create_pair, (token0, token1).abi_encode());
+        let new_pair_result =
+            run_tx(&mut db, &factory, calldata_create_pair, &ALICE).expect("Error executing tx");
+        assert!(new_pair_result.status, "Failed to create new pair");
+        let pair = Address::from_word(B256::from_slice(new_pair_result.output.as_slice()));
+
+        UniswapV2PairSetup {
+            db,
+            factory,
+            token0,
+            token1,
+            pair,
+            fee_to_setter: ALICE,
+        }
+    }
+
+    fn erc20_mint(db: &mut InMemoryDB, token: Address, to: Address, amount: U256) {
+        let selector_mint = get_selector_from_sig("mint(address,uint256)");
+        let calldata_mint = get_calldata(selector_mint, (to, amount).abi_encode());
+        let result = run_tx(db, &token, calldata_mint, &ALICE).expect("Error executing mint tx");
+        assert!(result.status, "Mint transaction failed");
+    }
+
+    fn erc20_transfer(db: &mut InMemoryDB, token: Address, to: Address, amount: U256) {
+        let selector_transfer = get_selector_from_sig("transfer(address,uint256)");
+        let calldata_transfer = get_calldata(selector_transfer, (to, amount).abi_encode());
+        let result =
+            run_tx(db, &token, calldata_transfer, &ALICE).expect("Error executing transfer tx");
+        assert!(result.status, "Transfer transaction failed");
+    }
+
+    fn erc20_balance(db: &mut InMemoryDB, token: Address, owner: Address) -> U256 {
+        let selector_balance_of = get_selector_from_sig("balance_of(address)");
+        let calldata_balance_of = get_calldata(selector_balance_of, owner.abi_encode());
+        let balance_result = run_tx(db, &token, calldata_balance_of, &ALICE)
+            .expect("Error executing balance_of tx")
+            .output;
+        B256::from_slice(&balance_result).into()
+    }
+
+    fn get_reserves(db: &mut InMemoryDB, pair: Address) -> (U256, U256, U256) {
+        let selector_get_reserves = get_selector_from_sig("get_reserves()");
+        let reserves_result = run_tx(db, &pair, selector_get_reserves.to_vec(), &ALICE)
+            .expect("Error executing get_reserves tx")
+            .output;
+
+        // Extract three U256 values from the output
+        let reserve0: U256 = B256::from_slice(&reserves_result[0..32]).into();
+        let reserve1: U256 = B256::from_slice(&reserves_result[32..64]).into();
+        let last_block_at: U256 = B256::from_slice(&reserves_result[64..96]).into();
+
+        (reserve0, reserve1, last_block_at)
+    }
+
+    fn get_total_supply(db: &mut InMemoryDB, pair: Address) -> U256 {
+        let selector_total_supply = get_selector_from_sig("total_supply()");
+        let total_supply_result = run_tx(db, &pair, selector_total_supply.to_vec(), &ALICE)
+            .expect("Error executing mint tx");
+        B256::from_slice(&total_supply_result.output).into()
+    }
+
+    fn add_liquidity(
+        db: &mut InMemoryDB,
+        pair: Address,
+        token0: Address,
+        token1: Address,
+        token0_amount: U256,
+        token1_amount: U256,
+    ) -> U256 {
+        // Transfer tokens to the pair contract
+        erc20_transfer(db, token0, pair, token0_amount);
+        erc20_transfer(db, token1, pair, token1_amount);
+
+        // Call mint
+        let selector_mint = get_selector_from_sig("mint(address)");
+        let calldata_mint = get_calldata(selector_mint, ALICE.abi_encode());
+        let mint_result =
+            run_tx(db, &pair, calldata_mint, &ALICE).expect("Error executing mint tx");
+        assert!(mint_result.status, "Mint transaction failed");
+
+        B256::from_slice(&mint_result.output).into()
+    }
+
+    #[test]
+    fn test_mint() {
+        let UniswapV2PairSetup {
+            mut db,
+            factory: _,
+            token0,
+            token1,
+            pair,
+            fee_to_setter: _,
+        } = pair_setup();
+
+        // Mint tokens to ALICE
+        let token0_amount = U256::from(1e18);
+        let token1_amount = U256::from(4e18);
+        erc20_mint(&mut db, token0, ALICE, token0_amount);
+        erc20_mint(&mut db, token1, ALICE, token1_amount);
+
+        // Transfer tokens to pair
+        warn!("TRANSFER");
+        erc20_transfer(&mut db, token0, pair, token0_amount);
+        erc20_transfer(&mut db, token1, pair, token1_amount);
+
+        // Call mint function
+        let expected_liquidity = U256::from(2e18);
+        let selector_mint = get_selector_from_sig("mint(address)");
+        let calldata_mint = get_calldata(selector_mint, ALICE.abi_encode());
+
+        let mint_result =
+            run_tx(&mut db, &pair, calldata_mint, &ALICE).expect("Error executing mint tx");
+        assert!(mint_result.status, "Mint transaction failed");
+
+        // Verify outputs
+        let total_supply = get_total_supply(&mut db, pair);
+        let alice_balance = erc20_balance(&mut db, pair, ALICE);
+        let (reserve0, reserve1, _) = get_reserves(&mut db, pair);
+
+        assert_eq!(total_supply, expected_liquidity, "Incorrect total supply");
+        assert_eq!(
+            alice_balance,
+            expected_liquidity - MINIMUM_LIQUIDITY,
+            "Incorrect ALICE balance"
+        );
+        assert_eq!(reserve0, token0_amount, "Incorrect reserve0");
+        assert_eq!(reserve1, token1_amount, "Incorrect reserve1");
+        assert_eq!(
+            erc20_balance(&mut db, token0, pair),
+            token0_amount,
+            "Incorrect token0 balance"
+        );
+        assert_eq!(
+            erc20_balance(&mut db, token1, pair),
+            token1_amount,
+            "Incorrect token1 balance"
+        );
+    }
+
+    #[test]
+    fn test_swap_token0() {
+        let UniswapV2PairSetup {
+            mut db,
+            factory: _,
+            token0,
+            token1,
+            pair,
+            fee_to_setter: _,
+        } = pair_setup();
+
+        // Setup initial liquidity
+        let token0_amount = U256::from(5e18);
+        let token1_amount = U256::from(10e18);
+
+        erc20_mint(&mut db, token0, ALICE, token0_amount);
+        erc20_mint(&mut db, token1, ALICE, token1_amount);
+        add_liquidity(&mut db, pair, token0, token1, token0_amount, token1_amount);
+
+        // Prepare swap
+        let swap_amount = U256::from(1e18);
+        let expected_output_amount = U256::from(1662497915624478906_u128);
+
+        erc20_mint(&mut db, token0, ALICE, swap_amount);
+        erc20_transfer(&mut db, token0, pair, swap_amount);
+
+        // Execute swap
+        let selector_swap = get_selector_from_sig("swap(uint256,uint256,address,bytes)");
+        let calldata_swap = get_calldata(
+            selector_swap,
+            (U256::ZERO, expected_output_amount, ALICE, Bytes::default()).abi_encode(),
+        );
+
+        let swap_result =
+            run_tx(&mut db, &pair, calldata_swap, &ALICE).expect("Error executing swap tx");
+        assert!(swap_result.status, "Swap transaction failed");
+
+        // Verify state after swap
+        let (reserve0, reserve1, _) = get_reserves(&mut db, pair);
+
+        assert_eq!(
+            reserve0,
+            token0_amount + swap_amount,
+            "Incorrect reserve0 after swap"
+        );
+        assert_eq!(
+            reserve1,
+            token1_amount - expected_output_amount,
+            "Incorrect reserve1 after swap"
+        );
+
+        // Check token balances
+        assert_eq!(
+            erc20_balance(&mut db, token0, pair),
+            token0_amount + swap_amount,
+            "Incorrect token0 balance after swap"
+        );
+        assert_eq!(
+            erc20_balance(&mut db, token1, pair),
+            token1_amount - expected_output_amount,
+            "Incorrect token1 balance after swap"
+        );
+    }
+
+    #[test]
+    fn test_swap_token1() {
+        let UniswapV2PairSetup {
+            mut db,
+            factory: _,
+            token0,
+            token1,
+            pair,
+            fee_to_setter: _,
+        } = pair_setup();
+
+        // Setup initial liquidity
+        let token0_amount = U256::from(5e18);
+        let token1_amount = U256::from(10e18);
+
+        erc20_mint(&mut db, token0, ALICE, token0_amount);
+        erc20_mint(&mut db, token1, ALICE, token1_amount);
+        add_liquidity(&mut db, pair, token0, token1, token0_amount, token1_amount);
+
+        // Prepare swap
+        let swap_amount = U256::from(1e18);
+        let expected_output_amount = U256::from(453305446940074565_u128);
+
+        erc20_mint(&mut db, token1, ALICE, swap_amount);
+        erc20_transfer(&mut db, token1, pair, swap_amount);
+
+        // Execute swap
+        let selector_swap = get_selector_from_sig("swap(uint256,uint256,address,bytes)");
+        let calldata_swap = get_calldata(
+            selector_swap,
+            (expected_output_amount, U256::ZERO, ALICE, Bytes::new()).abi_encode(),
+        );
+
+        let swap_result =
+            run_tx(&mut db, &pair, calldata_swap, &ALICE).expect("Error executing swap tx");
+        assert!(swap_result.status, "Swap transaction failed");
+
+        // Verify state after swap
+        let (reserve0, reserve1, _) = get_reserves(&mut db, pair);
+
+        assert_eq!(
+            reserve0,
+            token0_amount - expected_output_amount,
+            "Incorrect reserve0 after swap"
+        );
+        assert_eq!(
+            reserve1,
+            token1_amount + swap_amount,
+            "Incorrect reserve1 after swap"
+        );
+
+        // Check token balances
+        assert_eq!(
+            erc20_balance(&mut db, token0, pair),
+            token0_amount - expected_output_amount,
+            "Incorrect token0 balance after swap"
+        );
+        assert_eq!(
+            erc20_balance(&mut db, token1, pair),
+            token1_amount + swap_amount,
+            "Incorrect token1 balance after swap"
+        );
+    }
+
+    #[test]
+    fn test_burn() {
+        let UniswapV2PairSetup {
+            mut db,
+            factory: _,
+            token0,
+            token1,
+            pair,
+            fee_to_setter: _,
+        } = pair_setup();
+
+        // Setup initial liquidity
+        let token0_amount = U256::from(3e18);
+        let token1_amount = U256::from(3e18);
+
+        erc20_mint(&mut db, token0, ALICE, token0_amount);
+        erc20_mint(&mut db, token1, ALICE, token1_amount);
+        let alice_liquidity =
+            add_liquidity(&mut db, pair, token0, token1, token0_amount, token1_amount);
+        let total_supply = get_total_supply(&mut db, pair);
+
+        assert_eq!(
+            alice_liquidity,
+            total_supply - MINIMUM_LIQUIDITY,
+            "Incorrect liquidity"
+        );
+
+        // Record initial token balances of ALICE
+        let alice_token0_balance_before = erc20_balance(&mut db, token0, ALICE);
+        let alice_token1_balance_before = erc20_balance(&mut db, token1, ALICE);
+
+        // Transfer LP tokens to pair for burning
+        erc20_transfer(&mut db, pair, pair, alice_liquidity);
+
+        // Execute burn
+        let selector_burn = get_selector_from_sig("burn(address)");
+        let calldata_burn = get_calldata(selector_burn, ALICE.abi_encode());
+
+        let burn_result =
+            run_tx(&mut db, &pair, calldata_burn, &ALICE).expect("Error executing burn tx");
+        assert!(burn_result.status, "Burn transaction failed");
+
+        // Verify state after burn
+        let total_supply = get_total_supply(&mut db, pair);
+        let (reserve0, reserve1, _) = get_reserves(&mut db, pair);
+
+        // Validate state
+        assert_eq!(
+            total_supply, MINIMUM_LIQUIDITY,
+            "Total supply should equal MINIMUM_LIQUIDITY"
+        );
+        assert_eq!(reserve0, U256::from(1000), "Incorrect reserve0 after burn");
+        assert_eq!(reserve1, U256::from(1000), "Incorrect reserve1 after burn");
+
+        // Check token balances of pair and ALICE
+        assert_eq!(
+            erc20_balance(&mut db, token0, pair),
+            U256::from(1000),
+            "Incorrect token0 balance in pair"
+        );
+        assert_eq!(
+            erc20_balance(&mut db, token1, pair),
+            U256::from(1000),
+            "Incorrect token1 balance in pair"
+        );
+
+        // Alice's balance should have increased by almost the full amount (minus MINIMUM_LIQUIDITY)
+        let alice_token0_balance_after = erc20_balance(&mut db, token0, ALICE);
+        let alice_token1_balance_after = erc20_balance(&mut db, token1, ALICE);
+
+        assert_eq!(
+            alice_token0_balance_after - alice_token0_balance_before,
+            token0_amount - U256::from(1000),
+            "ALICE didn't receive expected token0 amount"
+        );
+        assert_eq!(
+            alice_token1_balance_after - alice_token1_balance_before,
+            token1_amount - U256::from(1000),
+            "ALICE didn't receive expected token1 amount"
+        );
+    }
+
+    #[test]
+    fn test_swap_insufficient_output_amount() {
+        let UniswapV2PairSetup {
+            mut db,
+            factory: _,
+            token0,
+            token1,
+            pair,
+            fee_to_setter: _,
+        } = pair_setup();
+
+        // Setup initial liquidity
+        let token0_amount = U256::from(5e18);
+        let token1_amount = U256::from(10e18);
+
+        erc20_mint(&mut db, token0, ALICE, token0_amount);
+        erc20_mint(&mut db, token1, ALICE, token1_amount);
+        add_liquidity(&mut db, pair, token0, token1, token0_amount, token1_amount);
+
+        // Execute swap with both amounts being zero
+        let selector_swap = get_selector_from_sig("swap(uint256,uint256,address,bytes)");
+        let calldata_swap = get_calldata(
+            selector_swap,
+            (U256::ZERO, U256::ZERO, ALICE, Bytes::new()).abi_encode(),
+        );
+
+        let result = run_tx(&mut db, &pair, calldata_swap, &ALICE)
+            .expect_err("Swap with zero outputs should fail");
+
+        assert!(
+            result.matches_custom_error("UniswapV2PairError::InsufficientOutputAmount"),
+            "Incorrect error for insufficient output amount"
+        );
+    }
+
+    #[test]
+    fn test_swap_exceeds_reserves() {
+        let UniswapV2PairSetup {
+            mut db,
+            factory: _,
+            token0,
+            token1,
+            pair,
+            fee_to_setter: _,
+        } = pair_setup();
+
+        // Setup initial liquidity
+        let token0_amount = U256::from(5e18);
+        let token1_amount = U256::from(10e18);
+
+        erc20_mint(&mut db, token0, ALICE, token0_amount);
+        erc20_mint(&mut db, token1, ALICE, token1_amount);
+        add_liquidity(&mut db, pair, token0, token1, token0_amount, token1_amount);
+
+        // Try to swap for more than reserves
+        let selector_swap = get_selector_from_sig("swap(uint256,uint256,address,bytes)");
+        let calldata_swap = get_calldata(
+            selector_swap,
+            (
+                token0_amount + U256::from(1),
+                U256::ZERO,
+                ALICE,
+                Bytes::new(),
+            )
+                .abi_encode(),
+        );
+
+        let result = run_tx(&mut db, &pair, calldata_swap, &ALICE)
+            .expect_err("Swap exceeding reserves should fail");
+
+        assert!(
+            result.matches_custom_error("UniswapV2PairError::InsufficientLiquidity"),
+            "Incorrect error for insufficient liquidity"
+        );
+    }
+
+    #[test]
+    fn test_swap_invalid_to() {
+        let UniswapV2PairSetup {
+            mut db,
+            factory: _,
+            token0,
+            token1,
+            pair,
+            fee_to_setter: _,
+        } = pair_setup();
+
+        // Setup initial liquidity
+        let token0_amount = U256::from(5e18);
+        let token1_amount = U256::from(10e18);
+
+        erc20_mint(&mut db, token0, ALICE, token0_amount);
+        erc20_mint(&mut db, token1, ALICE, token1_amount);
+        add_liquidity(&mut db, pair, token0, token1, token0_amount, token1_amount);
+
+        // Prepare swap with invalid destination (token address)
+        let swap_amount = U256::from(1e18);
+        let expected_output_amount = U256::from(1662497915624478906_u128);
+
+        erc20_mint(&mut db, token0, ALICE, swap_amount);
+        erc20_transfer(&mut db, token0, pair, swap_amount);
+
+        // Try swap with token0 as destination
+        let selector_swap = get_selector_from_sig("swap(uint256,uint256,address,bytes)");
+        let calldata_swap = get_calldata(
+            selector_swap,
+            (U256::ZERO, expected_output_amount, token0, Bytes::new()).abi_encode(),
+        );
+
+        let result = run_tx(&mut db, &pair, calldata_swap, &ALICE)
+            .expect_err("Swap to token address should fail");
+
+        assert!(
+            result.matches_custom_error("UniswapV2PairError::InvalidTo"),
+            "Incorrect error for invalid to address"
+        );
+    }
+
+    #[test]
+    fn test_swap_k_invariant() {
+        let UniswapV2PairSetup {
+            mut db,
+            factory: _,
+            token0,
+            token1,
+            pair,
+            fee_to_setter: _,
+        } = pair_setup();
+
+        // Setup initial liquidity
+        let token0_amount = U256::from(5e18);
+        let token1_amount = U256::from(10e18);
+
+        erc20_mint(&mut db, token0, ALICE, token0_amount);
+        erc20_mint(&mut db, token1, ALICE, token1_amount);
+        add_liquidity(&mut db, pair, token0, token1, token0_amount, token1_amount);
+
+        // Prepare swap
+        let swap_amount = U256::from(1e18);
+        // Try an output amount that's too high (breaking K invariant)
+        let too_high_output = U256::from(1662497915624478906_u128) + U256::from(1);
+
+        erc20_mint(&mut db, token0, ALICE, swap_amount);
+        erc20_transfer(&mut db, token0, pair, swap_amount);
+
+        // Execute swap with too high output
+        let selector_swap = get_selector_from_sig("swap(uint256,uint256,address,bytes)");
+        let calldata_swap = get_calldata(
+            selector_swap,
+            (U256::ZERO, too_high_output, ALICE, Bytes::new()).abi_encode(),
+        );
+
+        let result = run_tx(&mut db, &pair, calldata_swap, &ALICE)
+            .expect_err("Swap breaking K invariant should fail");
+
+        assert!(
+            result.matches_custom_error("UniswapV2PairError::K"),
+            "Incorrect error for K invariant violation"
+        );
+    }
+
+    #[test]
+    fn test_fee_to_off() {
+        let UniswapV2PairSetup {
+            mut db,
+            factory: _,
+            token0,
+            token1,
+            pair,
+            fee_to_setter: _,
+        } = pair_setup();
+
+        // Setup initial liquidity
+        let token0_amount = U256::from(1000e18);
+        let token1_amount = U256::from(1000e18);
+
+        erc20_mint(&mut db, token0, ALICE, token0_amount);
+        erc20_mint(&mut db, token1, ALICE, token1_amount);
+        add_liquidity(&mut db, pair, token0, token1, token0_amount, token1_amount);
+
+        // Perform a swap
+        let swap_amount = U256::from(1e18);
+        let expected_output_amount = U256::from(996006981039903216_u128);
+
+        erc20_mint(&mut db, token1, ALICE, swap_amount);
+        erc20_transfer(&mut db, token1, pair, swap_amount);
+
+        // Execute swap
+        let selector_swap = get_selector_from_sig("swap(uint256,uint256,address,bytes)");
+        let calldata_swap = get_calldata(
+            selector_swap,
+            (expected_output_amount, U256::ZERO, ALICE, Bytes::new()).abi_encode(),
+        );
+
+        run_tx(&mut db, &pair, calldata_swap, &ALICE).expect("Error executing swap tx");
+
+        // Transfer liquidity to pair and burn
+        let liquidity = erc20_balance(&mut db, pair, ALICE);
+        let selector_transfer = get_selector_from_sig("transfer(address,uint256)");
+        let calldata_transfer = get_calldata(selector_transfer, (pair, liquidity).abi_encode());
+
+        run_tx(&mut db, &pair, calldata_transfer, &ALICE).expect("Error executing transfer tx");
+
+        // Execute burn
+        let selector_burn = get_selector_from_sig("burn(address)");
+        let calldata_burn = get_calldata(selector_burn, ALICE.abi_encode());
+
+        run_tx(&mut db, &pair, calldata_burn, &ALICE).expect("Error executing burn tx");
+
+        // Verify total supply is just MINIMUM_LIQUIDITY since `fee_to` is not set
+        assert_eq!(
+            get_total_supply(&mut db, pair),
+            MINIMUM_LIQUIDITY,
+            "Total supply should equal MINIMUM_LIQUIDITY"
+        );
+    }
+
+    #[test]
+    fn test_fee_to_on() {
+        let UniswapV2PairSetup {
+            mut db,
+            factory,
+            token0,
+            token1,
+            pair,
+            fee_to_setter,
+        } = pair_setup();
+
+        // Set feeTo to BOB
+        let selector_set_fee_to = get_selector_from_sig("set_fee_to(address)");
+        let calldata_set_fee_to = get_calldata(selector_set_fee_to, BOB.abi_encode());
+
+        run_tx(&mut db, &factory, calldata_set_fee_to, &fee_to_setter)
+            .expect("Error executing set_fee_to tx");
+
+        // Setup initial liquidity
+        let token0_amount = U256::from(1000e18);
+        let token1_amount = U256::from(1000e18);
+
+        erc20_mint(&mut db, token0, ALICE, token0_amount);
+        erc20_mint(&mut db, token1, ALICE, token1_amount);
+        add_liquidity(&mut db, pair, token0, token1, token0_amount, token1_amount);
+
+        // Perform a swap
+        let swap_amount = U256::from(1e18);
+        let expected_output_amount = U256::from(996006981039903216_u128);
+
+        erc20_mint(&mut db, token1, ALICE, swap_amount);
+        erc20_transfer(&mut db, token1, pair, swap_amount);
+
+        // Execute swap
+        let selector_swap = get_selector_from_sig("swap(uint256,uint256,address,bytes)");
+        let calldata_swap = get_calldata(
+            selector_swap,
+            (expected_output_amount, U256::ZERO, ALICE, Bytes::new()).abi_encode(),
+        );
+
+        run_tx(&mut db, &pair, calldata_swap, &ALICE).expect("Error executing swap tx");
+
+        // Transfer liquidity to pair and burn
+        let liquidity = erc20_balance(&mut db, pair, ALICE);
+        let selector_transfer = get_selector_from_sig("transfer(address,uint256)");
+        let calldata_transfer = get_calldata(selector_transfer, (pair, liquidity).abi_encode());
+
+        run_tx(&mut db, &pair, calldata_transfer, &ALICE).expect("Error executing transfer tx");
+
+        // Execute burn
+        let selector_burn = get_selector_from_sig("burn(address)");
+        let calldata_burn = get_calldata(selector_burn, ALICE.abi_encode());
+
+        run_tx(&mut db, &pair, calldata_burn, &ALICE).expect("Error executing burn tx");
+
+        // Verify total supply is more than MINIMUM_LIQUIDITY due to fees
+        assert!(
+            get_total_supply(&mut db, pair) > MINIMUM_LIQUIDITY,
+            "Total supply should be greater than MINIMUM_LIQUIDITY"
+        );
+
+        // Check BOB's LP token balance
+        assert!(
+            erc20_balance(&mut db, pair, BOB) > U256::ZERO,
+            "BOB should have LP tokens from fees"
+        );
+    }
+
+    #[test]
+    fn test_price_update_after_swap() {
+        let UniswapV2PairSetup {
+            mut db,
+            factory: _,
+            token0,
+            token1,
+            pair,
+            fee_to_setter: _,
+        } = pair_setup();
+
+        // Setup initial liquidity
+        let token0_amount = U256::from(3e18);
+        let token1_amount = U256::from(3e18);
+
+        erc20_mint(&mut db, token0, ALICE, token0_amount * U256::from(2)); // Extra for swap
+        erc20_mint(&mut db, token1, ALICE, token1_amount);
+
+        add_liquidity(&mut db, pair, token0, token1, token0_amount, token1_amount);
+
+        // Sync the pair to set initial price accumulators
+        let selector_sync = get_selector_from_sig("sync()");
+        run_tx(&mut db, &pair, selector_sync.to_vec(), &ALICE).expect("Error executing sync tx");
+
+        // Get initial price accumulators
+        let selector_price0 = get_selector_from_sig("price0_cumulative_last()");
+        let selector_price1 = get_selector_from_sig("price1_cumulative_last()");
+
+        let price0_before_result = run_tx(&mut db, &pair, selector_price0.to_vec(), &ALICE)
+            .expect("Error executing price0_cumulative_last tx")
+            .output;
+        let price1_before_result = run_tx(&mut db, &pair, selector_price1.to_vec(), &ALICE)
+            .expect("Error executing price1_cumulative_last tx")
+            .output;
+
+        let price0_before: U256 = B256::from_slice(&price0_before_result).into();
+        let price1_before: U256 = B256::from_slice(&price1_before_result).into();
+
+        // Perform a swap to change the price ratio
+        let swap_amount = U256::from(3e18);
+        erc20_transfer(&mut db, token0, pair, swap_amount);
+
+        // Execute swap with 1 token output to make price change significant
+        let selector_swap = get_selector_from_sig("swap(uint256,uint256,address,bytes)");
+        let calldata_swap = get_calldata(
+            selector_swap,
+            (U256::ZERO, U256::from(1e18), ALICE, Bytes::new()).abi_encode(),
+        );
+
+        run_tx(&mut db, &pair, calldata_swap, &ALICE).expect("Error executing swap tx");
+
+        // Get updated price accumulators
+        let price0_after_result = run_tx(&mut db, &pair, selector_price0.to_vec(), &ALICE)
+            .expect("Error executing price0_cumulative_last tx")
+            .output;
+        let price1_after_result = run_tx(&mut db, &pair, selector_price1.to_vec(), &ALICE)
+            .expect("Error executing price1_cumulative_last tx")
+            .output;
+
+        let price0_after: U256 = B256::from_slice(&price0_after_result).into();
+        let price1_after: U256 = B256::from_slice(&price1_after_result).into();
+
+        // Verify price accumulators have updated
+        assert!(
+            price0_after >= price0_before,
+            "Price0 accumulator should increase or stay the same"
+        );
+        assert!(
+            price1_after >= price1_before,
+            "Price1 accumulator should increase or stay the same"
         );
     }
 }

--- a/r55/tests/uniswap-v2.rs
+++ b/r55/tests/uniswap-v2.rs
@@ -233,7 +233,7 @@ mod uniswap_v2_factory_tests {
 
         let new_fee_to = BOB;
 
-        // Set feeTo
+        // Set `fee_to`
         let selector_set_fee_to = get_selector_from_sig("set_fee_to(address)");
         let calldata_set_fee_to = get_calldata(selector_set_fee_to, new_fee_to.abi_encode());
 
@@ -242,7 +242,7 @@ mod uniswap_v2_factory_tests {
 
         assert!(set_fee_to_result.status, "Set `fee_to` transaction failed");
 
-        // Verify feeTo was updated
+        // Verify `fee_to` was updated
         let selector_fee_to = get_selector_from_sig("fee_to()");
         let fee_to_result = run_tx(&mut db, &factory, selector_fee_to.to_vec(), &fee_to_setter)
             .expect("Error executing tx")
@@ -251,7 +251,7 @@ mod uniswap_v2_factory_tests {
         assert_eq!(
             Address::from_word(B256::from_slice(fee_to_result.as_slice())),
             new_fee_to,
-            "feeTo was not updated correctly"
+            "`fee_to` was not updated correctly"
         );
     }
 
@@ -266,7 +266,7 @@ mod uniswap_v2_factory_tests {
         let unauthorized = BOB;
         let new_fee_to = CAROL;
 
-        // Try to set feeTo with unauthorized account
+        // Try to set `fee_to` with unauthorized account
         let selector_set_fee_to = get_selector_from_sig("set_fee_to(address)");
         let calldata_set_fee_to = get_calldata(selector_set_fee_to, new_fee_to.abi_encode());
 
@@ -289,7 +289,7 @@ mod uniswap_v2_factory_tests {
 
         let new_fee_to_setter = BOB;
 
-        // Set feeToSetter
+        // Set `fee_to_setter`
         let selector_set_fee_to_setter = get_selector_from_sig("set_fee_to_setter(address)");
         let calldata_set_fee_to_setter =
             get_calldata(selector_set_fee_to_setter, new_fee_to_setter.abi_encode());
@@ -304,10 +304,10 @@ mod uniswap_v2_factory_tests {
 
         assert!(
             set_fee_to_setter_result.status,
-            "Set feeToSetter transaction failed"
+            "Set `fee_to_setter` transaction failed"
         );
 
-        // Verify feeToSetter was updated
+        // Verify `fee_to_setter` was updated
         let selector_fee_to_setter = get_selector_from_sig("fee_to_setter()");
         let fee_to_setter_result =
             run_tx(&mut db, &factory, selector_fee_to_setter.to_vec(), &ALICE)
@@ -317,7 +317,7 @@ mod uniswap_v2_factory_tests {
         assert_eq!(
             Address::from_slice(&fee_to_setter_result[12..32]),
             new_fee_to_setter,
-            "feeToSetter was not updated correctly"
+            "`fee_to_setter` was not updated correctly"
         );
     }
 
@@ -332,7 +332,7 @@ mod uniswap_v2_factory_tests {
         let unauthorized = BOB;
         let new_fee_to_setter = CAROL;
 
-        // Try to set feeToSetter with unauthorized account
+        // Try to set `fee_to_setter` with unauthorized account
         let selector_set_fee_to_setter = get_selector_from_sig("set_fee_to_setter(address)");
         let calldata_set_fee_to_setter =
             get_calldata(selector_set_fee_to_setter, new_fee_to_setter.abi_encode());
@@ -357,14 +357,14 @@ mod uniswap_v2_factory_tests {
         let new_fee_to = BOB;
         let new_fee_to_setter = CAROL;
 
-        // First set feeTo to a new address
+        // First set `fee_to` to a new address
         let selector_set_fee_to = get_selector_from_sig("set_fee_to(address)");
         let calldata_set_fee_to = get_calldata(selector_set_fee_to, new_fee_to.abi_encode());
 
         run_tx(&mut db, &factory, calldata_set_fee_to, &fee_to_setter)
             .expect("Error executing set_fee_to tx");
 
-        // Then set feeToSetter to a new address
+        // Then set `fee_to_setter` to a new address
         let selector_set_fee_to_setter = get_selector_from_sig("set_fee_to_setter(address)");
         let calldata_set_fee_to_setter =
             get_calldata(selector_set_fee_to_setter, new_fee_to_setter.abi_encode());
@@ -377,7 +377,7 @@ mod uniswap_v2_factory_tests {
         )
         .expect("Error executing set_fee_to_setter tx");
 
-        // Try to set feeToSetter again with the original feeToSetter (should fail)
+        // Try to set `fee_to_setter` again with the original `fee_to_setter` (should fail)
         let calldata_set_fee_to_setter_again =
             get_calldata(selector_set_fee_to_setter, BOB.abi_encode());
 
@@ -1017,7 +1017,7 @@ mod uniswap_v2_pair_tests {
             fee_to_setter,
         } = pair_setup();
 
-        // Set feeTo to BOB
+        // Set `fee_to` to BOB
         let selector_set_fee_to = get_selector_from_sig("set_fee_to(address)");
         let calldata_set_fee_to = get_calldata(selector_set_fee_to, BOB.abi_encode());
 


### PR DESCRIPTION
this PR aimed to showcase the impl of a slightly more advanced set of contracts like uniswap-v2 (both pair + factory).

however, it made me realize several limitations of the compilation pipeline, such as the fact that the initial impl was limited to 1 contract per crate. Despite this limitation still holds -we can only have 1 entry point per binary + their bytecode should be independent to reduce contract size and cyclical dependency loops-, i propose a PoC for a more versatile (and complex) compilation process.

## r55-compile
- revamped so that users can define several contracts (in separate mods) which share a common project. See `uniswap-v2/pair.rs` and `uniswap-v2/factory.rs`.
- the pipeline identifies all the necessary dependencies, including common mods like `uniswap-v2/math.rs` (for the time being, any module imported on `lib.rs` which doesn't have a contract is considered common. If we like the PoC, we would enhance AST analysis to only inject the necessary non-contracts mods for each contract). Then it generates an isolates a flattened version of each crate under `target/r55-generated/` --> note that right now i only keep them for debugging purposes, but once the output bytecode is generated, they could be auto-cleared by the script itself.
- the pipeline still accounts for compilation order based on contract dependencies, and still generates the deployable impls. However, i added more fine-grained control over contract deps based their intended usecase:
    - `interface-only`: informed as a regular dep, with its feature flag --> imports the interface to interact with the contract
    - `deployable`: since deployable impl will be generated after the temp crate (with flattening) creation, users will have to add metadata to the `Cargo.toml` to inform the module/crate that should be deployable. 
    
    for instance, this toml will crate `target/r55-generated/uniswap-v2/factory/deployable.rs` with the bytecode of `target/r55-generated/uniswap-v2/pair/lib.rs`. It will also make `erc20::IERC20` available to both binaries.
```
# uniswap-v2/Cargo.toml

[package.metadata.deployable_deps]
pair = { path = "." }

[dependencies]
erc20 = { path = "../erc20", features = ["interface-only"] }
```

## Built-in reentrancy guard
- added a new storage type `Lock` which implements a built-in reentrancy guard, UX is quite cool imo, as users only ned to:
   1. initialize the lock in the constructor when deploying the contract.
   2. aquire the guard in the re-entrancy protected fn
- `Lock` automatically writes back to storage when dropped, releasing the guard

## Leverage rust docs for better dev-ex
- auto-generated doc comments for interfaces, so that the LSP shows the available methods

## enhanced contract macro to support private fns
- edgecase we hadn't considered before

## Address opcode
- added fn address(&self) -> Address to contracts, so that they can know their own address (analogous to `address(this)` in solidity.

## extend MappingGuard
- implemented several core utils like `AddAssign` to have better mapping UX:
```
// before
let to_balance = self.balance_of[to].read();
self.balance_of[to].write(to_balance + amount);

// now
self.balance_of[to] += amount;
```

## Pending TODOs:
to be tackled in other PRs
- impl ecrecover
- dynamic storage types (vecs, strings, etc)
- dev-friendly keccack impl passing bytes rather than pointers (super easy, but this PR is already touching so much stuff)
- figure out how to use `U8` as it doesn't seem to impl `SolValue`:  https://github.com/alloy-rs/core/blob/cd4b8d5e77e38d71534742fa4fb0505505b2ca2d/crates/sol-types/src/types/value.rs#L221
- impl CREATE 2 (should also be easy now that CREATE is already supported)
