### PR TITLE
improve(events): add static emit function to Event macro

### DIFF
--- a/contract-derive/src/lib.rs
+++ b/contract-derive/src/lib.rs
@@ -216,6 +216,11 @@ pub fn event_derive(input: TokenStream) -> TokenStream {
                     #(#field_names),*
                 }
             }
+
+            pub fn emit(#(#field_names: #field_types),*) {
+                let event = Self::new(#(#field_names),*);
+                eth_riscv_runtime::log::emit(event);
+            }
         }
 
         impl eth_riscv_runtime::log::Event for #name {

--- a/examples/erc20/src/lib.rs
+++ b/examples/erc20/src/lib.rs
@@ -106,7 +106,7 @@ impl ERC20 {
         // Update state
         self.allowance_of[owner][spender].write(amount);
 
-        // Emit event + return usando la nueva sintaxis
+        // Emit event + return
         Approval::emit(owner, spender, amount);
         Ok(true)
     }
@@ -130,7 +130,7 @@ impl ERC20 {
         self.balance_of[from].write(from_balance - amount);
         self.balance_of[to].write(to_balance + amount);
 
-        // Emit event + return usando la nueva sintaxis
+        // Emit event + return
         Transfer::emit(from, to, amount);
         Ok(true)
     }
@@ -158,7 +158,7 @@ impl ERC20 {
         let to_balance = self.balance_of[to].read();
         self.balance_of[to].write(to_balance + amount);
 
-        // Emit event + return usando la nueva sintaxis
+        // Emit event + return
         Transfer::emit(from, to, amount);
         Ok(true)
     }
@@ -173,7 +173,7 @@ impl ERC20 {
         // Update state
         self.owner.write(new_owner);
 
-        // Emit event + return usando la nueva sintaxis
+        // Emit event + return
         OwnershipTransferred::emit(from, new_owner);
         Ok(true)
     }

--- a/examples/erc20/src/lib.rs
+++ b/examples/erc20/src/lib.rs
@@ -92,7 +92,7 @@ impl ERC20 {
         self.total_supply += amount;
         
         // Emit event + return `true` to stick to (EVM) ERC20 convention
-        log::emit(Transfer::new(Address::ZERO, to, amount));
+        Transfer::emit(Address::ZERO, to, amount);
         Ok(true)
     }
 
@@ -106,8 +106,8 @@ impl ERC20 {
         // Update state
         self.allowance_of[owner][spender].write(amount);
 
-        // Emit event + return 
-        log::emit(Approval::new(owner, spender, amount));
+        // Emit event + return usando la nueva sintaxis
+        Approval::emit(owner, spender, amount);
         Ok(true)
     }
 
@@ -130,8 +130,8 @@ impl ERC20 {
         self.balance_of[from].write(from_balance - amount);
         self.balance_of[to].write(to_balance + amount);
 
-        // Emit event + return 
-        log::emit(Transfer::new(from, to, amount));
+        // Emit event + return usando la nueva sintaxis
+        Transfer::emit(from, to, amount);
         Ok(true)
     }
 
@@ -158,8 +158,8 @@ impl ERC20 {
         let to_balance = self.balance_of[to].read();
         self.balance_of[to].write(to_balance + amount);
 
-        // Emit event + return 
-        log::emit(Transfer::new(from, to, amount));
+        // Emit event + return usando la nueva sintaxis
+        Transfer::emit(from, to, amount);
         Ok(true)
     }
 
@@ -173,8 +173,8 @@ impl ERC20 {
         // Update state
         self.owner.write(new_owner);
 
-        // Emit event + return 
-        log::emit(OwnershipTransferred::new(from, new_owner));
+        // Emit event + return usando la nueva sintaxis
+        OwnershipTransferred::emit(from, new_owner);
         Ok(true)
     }
 

--- a/examples/erc721/src/lib.rs
+++ b/examples/erc721/src/lib.rs
@@ -106,7 +106,7 @@ impl ERC721 {
         self.total_supply.write(total_supply + U256::from(1));
         
         // Emit event + return
-        log::emit(Transfer::new(Address::ZERO, to, id));
+        Transfer::emit(Address::ZERO, to, id);
         Ok(true)
     }
 
@@ -122,7 +122,7 @@ impl ERC721 {
         self.approval_of[id].write(spender);
 
         // Emit event + return
-        log::emit(Approval::new(owner, spender, id));
+        Approval::emit(owner, spender, id);
         Ok(true)
     }
 
@@ -133,7 +133,7 @@ impl ERC721 {
         self.is_operator[msg_sender][operator].write(approved);
 
         // Emit event + return
-        log::emit(ApprovalForAll::new(msg_sender, operator, approved));
+        ApprovalForAll::emit(msg_sender, operator, approved);
         Ok(true)
     }
 
@@ -161,7 +161,7 @@ impl ERC721 {
         self.balance_of[to].write(balance_to + U256::from(1));
 
         // Emit event + return
-        log::emit(Transfer::new(from, to, id));
+        Transfer::emit(from, to, id);
         Ok(true)
     }
 
@@ -174,7 +174,7 @@ impl ERC721 {
         self.owner.write(new_owner);
 
         // Emit event + return 
-        log::emit(OwnershipTransferred::new(from, new_owner));
+        OwnershipTransferred::emit(from, new_owner);
         Ok(true)
     }
 

--- a/r55/src/test_utils.rs
+++ b/r55/src/test_utils.rs
@@ -6,7 +6,6 @@ pub use revm::{
     InMemoryDB,
 };
 use std::{fs, path::Path, sync::Once};
-use tracing::info;
 
 static INIT: Once = Once::new();
 

--- a/r55/src/test_utils.rs
+++ b/r55/src/test_utils.rs
@@ -2,10 +2,11 @@ use alloy_core::hex::FromHex;
 use alloy_primitives::address;
 use revm::Database;
 pub use revm::{
-    primitives::{keccak256, ruint::Uint, AccountInfo, Address, Bytecode, Bytes, U256},
+    primitives::{keccak256, ruint::Uint, AccountInfo, Address, Bytecode, Bytes, Log, U256},
     InMemoryDB,
 };
 use std::{fs, path::Path, sync::Once};
+use tracing::info;
 
 static INIT: Once = Once::new();
 
@@ -70,4 +71,21 @@ pub fn load_bytecode_from_file<P: AsRef<Path>>(path: P) -> Bytes {
     let content = fs::read_to_string(path).expect("Unable to load bytecode from path");
     let trimmed = content.trim().trim_start_matches("0x");
     Bytes::from_hex(trimmed).expect("Unable to parse file content as bytes")
+}
+
+pub fn print_event_logs(logs: &[Log], title: Option<&str>) {
+    if let Some(title) = title {
+        info!("=== {} ===", title);
+    }
+    
+    if logs.is_empty() {
+        info!("No events emitted");
+        return;
+    }
+    
+    for (i, log) in logs.iter().enumerate() {
+        info!("Event #{}: ", i + 1);
+        info!("  Contract Address: {}", log.address);
+        info!("  Log details: {:#?}", log);
+    }
 }

--- a/r55/src/test_utils.rs
+++ b/r55/src/test_utils.rs
@@ -72,20 +72,3 @@ pub fn load_bytecode_from_file<P: AsRef<Path>>(path: P) -> Bytes {
     let trimmed = content.trim().trim_start_matches("0x");
     Bytes::from_hex(trimmed).expect("Unable to parse file content as bytes")
 }
-
-pub fn print_event_logs(logs: &[Log], title: Option<&str>) {
-    if let Some(title) = title {
-        info!("=== {} ===", title);
-    }
-    
-    if logs.is_empty() {
-        info!("No events emitted");
-        return;
-    }
-    
-    for (i, log) in logs.iter().enumerate() {
-        info!("Event #{}: ", i + 1);
-        info!("  Contract Address: {}", log.address);
-        info!("  Log details: {:#?}", log);
-    }
-}


### PR DESCRIPTION
- Add static emit() function to #[derive(Event)] macro
- Simplify event emission syntax from log::emit(Event::new()) to Event::emit()
- Update all event emissions in ERC20 contract
- Update all event emissions in ERC721 contract
- Add print_event_logs utility function for testing

https://github.com/r55-eth/r55/issues/48